### PR TITLE
Add luacheck

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,0 +1,13 @@
+name: luacheck
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: apt
+      run: sudo apt-get install -y luarocks
+    - name: luacheck install
+      run: luarocks install --local luacheck
+    - name: luacheck run
+      run: $HOME/.luarocks/bin/luacheck ./

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,5 @@
 unused_args = false
+max_line_length = 300  -- TODO: fix line lengths
 
 globals = {
     "minetest",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,21 @@
+unused_args = false
+
+globals = {
+    "minetest",
+	"digistuff",
+	"digilines",
+}
+
+read_globals = {
+	-- Builtin
+	table = {fields = {"copy"}},
+
+	"vector",
+	"ItemStack",
+	"DIR_DELIM",
+	
+	-- Mod Deps
+	"default",
+	"mesecon",
+	"screwdriver",
+}

--- a/camera.lua
+++ b/camera.lua
@@ -74,7 +74,6 @@ minetest.register_abm({
 			local players_found = {}
 			local objs = minetest.get_objects_inside_radius(spot,radius)
 			if objs then
-				local _,obj
 				for _,obj in ipairs(objs) do
 					if obj:is_player() then
 						table.insert(players_found,obj:get_player_name())

--- a/camera.lua
+++ b/camera.lua
@@ -83,7 +83,7 @@ minetest.register_abm({
 					end
 				end
 				if found_any then
-					digiline:receptor_send({x=pos.x,y=pos.y-1,z=pos.z}, digiline.rules.default, channel, players_found)
+					digilines.receptor_send({x=pos.x,y=pos.y-1,z=pos.z}, digilines.rules.default, channel, players_found)
 				end
 			end
 		end

--- a/camera.lua
+++ b/camera.lua
@@ -7,8 +7,7 @@ minetest.register_node("digistuff:camera", {
 		"digistuff_camera_back.png",
 		"digistuff_camera_front.png",
 	},
-	digiline = 
-	{
+	digiline = {
 		receptor = {}
 	},
 	_digistuff_channelcopier_fieldname = "channel",

--- a/cardreader.lua
+++ b/cardreader.lua
@@ -33,7 +33,6 @@ minetest.register_craftitem("digistuff:card",{
 			stackmeta:set_string("description",string.format("Magnetic Card (%s)",meta:get_string("writedescription")))
 			return stack
 		else
-			local channel = meta:get_string("channel")
 			local data = stackmeta:get_string("data")
 			digilines.receptor_send(pos,cardreader_rules,channel,{event = "read",data = data,})
 		end

--- a/cardreader.lua
+++ b/cardreader.lua
@@ -28,14 +28,14 @@ minetest.register_craftitem("digistuff:card",{
 			local data = meta:get_string("writedata")
 			meta:set_int("writepending",0)
 			meta:set_string("infotext","Ready to Read")
-			digiline:receptor_send(pos,cardreader_rules,channel,{event = "write",})
+			digilines.receptor_send(pos,cardreader_rules,channel,{event = "write",})
 			stackmeta:set_string("data",data)
 			stackmeta:set_string("description",string.format("Magnetic Card (%s)",meta:get_string("writedescription")))
 			return stack
 		else
 			local channel = meta:get_string("channel")
 			local data = stackmeta:get_string("data")
-			digiline:receptor_send(pos,cardreader_rules,channel,{event = "read",data = data,})
+			digilines.receptor_send(pos,cardreader_rules,channel,{event = "read",data = data,})
 		end
 	end,
 })

--- a/conductors.lua
+++ b/conductors.lua
@@ -79,7 +79,6 @@ minetest.register_node("digistuff:junctionbox", {
 	paramtype2 = "facedir",
 	groups = {cracky = 3},
 	is_ground_content = false,
-	paramtype = "light",
 	drawtype = "nodebox",
 	node_box = {
 		type = "fixed",
@@ -124,7 +123,6 @@ minetest.register_node("digistuff:receiver", {
 	groups = {dig_immediate = 3,not_in_creative_inventory = 1,},
 	drop = "digilines:wire_std_00000000",
 	is_ground_content = false,
-	paramtype = "light",
 	paramtype2 = "facedir",
 	walkable = false,
 	drawtype = "nodebox",
@@ -190,7 +188,6 @@ minetest.register_node("digistuff:vertical_tap", {
 	paramtype = "light",
 	groups = {dig_immediate = 3,vertical_digiline = 1,},
 	is_ground_content = false,
-	paramtype = "light",
 	drawtype = "nodebox",
 	node_box = {
 		type = "fixed",
@@ -228,7 +225,6 @@ minetest.register_node("digistuff:vertical_bottom", {
 	paramtype = "light",
 	groups = {dig_immediate = 3,vertical_digiline = 1,},
 	is_ground_content = false,
-	paramtype = "light",
 	drawtype = "nodebox",
 	node_box = {
 		type = "fixed",
@@ -267,7 +263,6 @@ minetest.register_node("digistuff:vertical_middle", {
 	groups = {dig_immediate = 3,not_in_creative_inventory = 1,vertical_digiline = 1,},
 	drop = "digistuff:vertical_bottom",
 	is_ground_content = false,
-	paramtype = "light",
 	walkable = false,
 	drawtype = "nodebox",
 	node_box = {
@@ -296,7 +291,6 @@ minetest.register_node("digistuff:vertical_top", {
 	groups = {dig_immediate = 3,not_in_creative_inventory = 1,vertical_digiline = 1,},
 	drop = "digistuff:vertical_bottom",
 	is_ground_content = false,
-	paramtype = "light",
 	drawtype = "nodebox",
 	node_box = {
 		type = "fixed",
@@ -336,7 +330,6 @@ minetest.register_node("digistuff:insulated_straight", {
 	on_rotate = minetest.get_modpath("screwdriver") and screwdriver.rotate_simple,
 	groups = {dig_immediate = 3,},
 	is_ground_content = false,
-	paramtype = "light",
 	drawtype = "nodebox",
 	node_box = {
 		type = "fixed",
@@ -382,7 +375,6 @@ minetest.register_node("digistuff:insulated_tjunction", {
 	on_rotate = minetest.get_modpath("screwdriver") and screwdriver.rotate_simple,
 	groups = {dig_immediate = 3,},
 	is_ground_content = false,
-	paramtype = "light",
 	drawtype = "nodebox",
 	node_box = {
 		type = "fixed",
@@ -430,7 +422,6 @@ minetest.register_node("digistuff:insulated_corner", {
 	on_rotate = minetest.get_modpath("screwdriver") and screwdriver.rotate_simple,
 	groups = {dig_immediate = 3,},
 	is_ground_content = false,
-	paramtype = "light",
 	drawtype = "nodebox",
 	node_box = {
 		type = "fixed",
@@ -475,7 +466,6 @@ minetest.register_node("digistuff:insulated_fourway", {
 	walkable = false,
 	groups = {dig_immediate = 3,},
 	is_ground_content = false,
-	paramtype = "light",
 	drawtype = "nodebox",
 	node_box = {
 		type = "fixed",

--- a/controller.lua
+++ b/controller.lua
@@ -61,7 +61,7 @@ local function process_inputs(pos)
 	last_seen_inputs[name] = inputs
 	if send_needed then
 		local channel = meta:get_string("channel")
-		local inputs = table.copy(inputs)
+		inputs = table.copy(inputs)
 		inputs.look_vector = player:get_look_dir()
 		inputs.name = name
 		digilines.receptor_send(pos,digiline_rules,channel,inputs)
@@ -181,7 +181,6 @@ minetest.register_node("digistuff:controller_programmed", {
 			toggle_trap_player(pos,clicker)
 		end
 	end,
-	_digistuff_channelcopier_fieldname = "channel",
 	digiline = {
 		receptor = {},
 		wire = {

--- a/controller.lua
+++ b/controller.lua
@@ -31,14 +31,14 @@ local function process_inputs(pos)
 	local name = players_on_controller[hash]
 	local player = minetest.get_player_by_name(name)
 	if not player then
-		digiline:receptor_send(pos,digiline_rules,meta:get_string("channel"),"player_left")
+		digilines.receptor_send(pos,digiline_rules,meta:get_string("channel"),"player_left")
 		minetest.get_meta(pos):set_string("infotext","Digilines Game Controller Ready\n(right-click to use)")
 		players_on_controller[hash] = nil
 		return
 	end
 	local distance = vector.distance(pos,player:get_pos())
 	if distance > 1 then
-		digiline:receptor_send(pos,digiline_rules,meta:get_string("channel"),"player_left")
+		digilines.receptor_send(pos,digiline_rules,meta:get_string("channel"),"player_left")
 		minetest.get_meta(pos):set_string("infotext","Digilines Game Controller Ready\n(right-click to use)")
 		player:set_physics_override({speed = 1,jump = 1,})
 		players_on_controller[hash] = nil
@@ -64,7 +64,7 @@ local function process_inputs(pos)
 		local inputs = table.copy(inputs)
 		inputs.look_vector = player:get_look_dir()
 		inputs.name = name
-		digiline:receptor_send(pos,digiline_rules,channel,inputs)
+		digilines.receptor_send(pos,digiline_rules,channel,inputs)
 	end
 end
 
@@ -80,7 +80,7 @@ local function release_player(pos)
 	meta:set_string("infotext","Digilines Game Controller Ready\n(right-click to use)")
 	last_seen_inputs[players_on_controller[hash]] = nil
 	players_on_controller[hash] = nil
-	digiline:receptor_send(pos,digiline_rules,meta:get_string("channel"),"player_left")
+	digilines.receptor_send(pos,digiline_rules,meta:get_string("channel"),"player_left")
 end
 
 local function trap_player(pos,player)
@@ -222,7 +222,7 @@ minetest.register_lbm({
 	action = function(pos)
 		if not players_on_controller[minetest.hash_node_position(pos)] then
 			local meta = minetest.get_meta(pos)
-			digiline:receptor_send(pos,digiline_rules,meta:get_string("channel"),"player_left")
+			digilines.receptor_send(pos,digiline_rules,meta:get_string("channel"),"player_left")
 			meta:set_string("infotext","Digilines Game Controller Ready\n(right-click to use)")
 		end
 	end,

--- a/detector.lua
+++ b/detector.lua
@@ -39,7 +39,6 @@ minetest.register_abm({
 			if not radius or not tonumber(radius) or tonumber(radius) < 1 or tonumber(radius) > 10 then radius = 6 end
 			local objs = minetest.get_objects_inside_radius(pos, radius)
 			if objs then
-				local _,obj
 				for _,obj in ipairs(objs) do
 					if obj:is_player() then
 						table.insert(players_found,obj:get_player_name())

--- a/detector.lua
+++ b/detector.lua
@@ -48,7 +48,7 @@ minetest.register_abm({
 					end
 				end
 				if found_any then
-					digiline:receptor_send(pos, digiline.rules.default, channel, players_found)
+					digilines.receptor_send(pos, digilines.rules.default, channel, players_found)
 				end
 			end
 		end

--- a/detector.lua
+++ b/detector.lua
@@ -2,8 +2,7 @@ minetest.register_node("digistuff:detector", {
 	tiles = {
 	"digistuff_digidetector.png"
 	},
-	digiline = 
-	{
+	digiline = {
 		receptor = {}
 	},
 	groups = {cracky=2},

--- a/gpu.lua
+++ b/gpu.lua
@@ -73,7 +73,7 @@ local function hsvtorgb(h,s,v)
 		b = c
 	else
 		r = c
-		b = x 
+		b = x
 	end
 	r = r+m
 	g = g+m
@@ -400,8 +400,7 @@ minetest.register_node("digistuff:gpu", {
 		local meta = minetest.get_meta(pos)
 		if fields.channel then meta:set_string("channel",fields.channel) end
 	end,
-	digiline = 
-	{
+	digiline = {
 		receptor = {},
 		effector = {
 			action = function(pos,node,channel,msg)

--- a/gpu.lua
+++ b/gpu.lua
@@ -20,9 +20,9 @@ local function rgbtohsv(r,g,b)
 	r = r/255
 	g = g/255
 	b = b/255
-	max = math.max(r,g,b)
-	min = math.min(r,g,b)
-	delta = max-min
+	local max = math.max(r,g,b)
+	local min = math.min(r,g,b)
+	local delta = max-min
 	local hue = 0
 	if delta > 0 then
 		if max == r then

--- a/gpu.lua
+++ b/gpu.lua
@@ -199,7 +199,7 @@ local function runcommand(pos,meta,command)
 		if string.len(buffer) == 0 then return end
 		buffer = minetest.deserialize(buffer)
 		if type(buffer) == "table" then
-			digiline:receptor_send(pos,digiline.rules.default,command.channel,buffer)
+			digilines.receptor_send(pos,digilines.rules.default,command.channel,buffer)
 		end
 	elseif command.command == "drawrect" then
 		if type(command.buffer) ~= "number" or type(command.x1) ~= "number" or type(command.y1) ~= "number" or type(command.x2) ~= "number" or type(command.y2) ~= "number" then return end

--- a/ioexpander.lua
+++ b/ioexpander.lua
@@ -99,7 +99,6 @@ local ioexp_handle_mesecons = function(pos,_,rule,state)
 	local meta = minetest.get_meta(pos)
 	local port = ioexp_rule_to_port(rule)
 	if not port then return end
-	local meta = minetest.get_meta(pos)
 	meta:set_int(port.."on",state == "on" and 1 or 0)
 	ioexp_digiline_send(pos)
 end

--- a/ioexpander.lua
+++ b/ioexpander.lua
@@ -65,7 +65,7 @@ local ioexp_digiline_send = function(pos)
 	}
 	local outstate = explode_port_states(meta:get_int("outstate"))
 	for k,v in pairs(outstate) do port[k] = port[k] or v end
-	digiline:receptor_send(pos,digiline.rules.default,channel,port)
+	digilines.receptor_send(pos,digilines.rules.default,channel,port)
 end
 
 local ioexp_handle_digilines = function(pos,node,channel,msg)

--- a/memory.lua
+++ b/memory.lua
@@ -53,7 +53,7 @@ minetest.register_node("digistuff:ram", {
 				if meta:get_string("channel") ~= channel or type(msg) ~= "table" then return end
 				if msg.command == "read" then
 					if type(msg.address) == "number" and msg.address >= 0 and msg.address <= 31 then
-						digiline:receptor_send(pos,digiline.rules.default,channel,meta:get_string(string.format("data%02i",math.floor(msg.address))))					
+						digilines.receptor_send(pos,digilines.rules.default,channel,meta:get_string(string.format("data%02i",math.floor(msg.address))))					
 					end
 				elseif msg.command == "write" then
 					if type(msg.address) == "number" and msg.address >= 0 and msg.address <= 31 and type(msg.data) == "string" then
@@ -146,7 +146,7 @@ minetest.register_node("digistuff:eeprom", {
 				if meta:get_string("channel") ~= channel or type(msg) ~= "table" then return end
 				if msg.command == "read" then
 					if type(msg.address) == "number" and msg.address >= 0 and msg.address <= 31 then
-						digiline:receptor_send(pos,digiline.rules.default,channel,meta:get_string(string.format("data%02i",math.floor(msg.address))))					
+						digilines.receptor_send(pos,digilines.rules.default,channel,meta:get_string(string.format("data%02i",math.floor(msg.address))))					
 					end
 				elseif msg.command == "write" then
 					if type(msg.address) == "number" and msg.address >= 0 and msg.address <= 31 and type(msg.data) == "string" then

--- a/memory.lua
+++ b/memory.lua
@@ -44,8 +44,7 @@ minetest.register_node("digistuff:ram", {
 		local meta = minetest.get_meta(pos)
 		if fields.channel then meta:set_string("channel",fields.channel) end
 	end,
-	digiline = 
-	{
+	digiline = {
 		receptor = {},
 		effector = {
 			action = function(pos,node,channel,msg)
@@ -53,7 +52,7 @@ minetest.register_node("digistuff:ram", {
 				if meta:get_string("channel") ~= channel or type(msg) ~= "table" then return end
 				if msg.command == "read" then
 					if type(msg.address) == "number" and msg.address >= 0 and msg.address <= 31 then
-						digilines.receptor_send(pos,digilines.rules.default,channel,meta:get_string(string.format("data%02i",math.floor(msg.address))))					
+						digilines.receptor_send(pos,digilines.rules.default,channel,meta:get_string(string.format("data%02i",math.floor(msg.address))))
 					end
 				elseif msg.command == "write" then
 					if type(msg.address) == "number" and msg.address >= 0 and msg.address <= 31 and type(msg.data) == "string" then
@@ -137,8 +136,7 @@ minetest.register_node("digistuff:eeprom", {
 		local meta = minetest.get_meta(pos)
 		if fields.channel then meta:set_string("channel",fields.channel) end
 	end,
-	digiline = 
-	{
+	digiline = {
 		receptor = {},
 		effector = {
 			action = function(pos,node,channel,msg)
@@ -146,7 +144,7 @@ minetest.register_node("digistuff:eeprom", {
 				if meta:get_string("channel") ~= channel or type(msg) ~= "table" then return end
 				if msg.command == "read" then
 					if type(msg.address) == "number" and msg.address >= 0 and msg.address <= 31 then
-						digilines.receptor_send(pos,digilines.rules.default,channel,meta:get_string(string.format("data%02i",math.floor(msg.address))))					
+						digilines.receptor_send(pos,digilines.rules.default,channel,meta:get_string(string.format("data%02i",math.floor(msg.address))))
 					end
 				elseif msg.command == "write" then
 					if type(msg.address) == "number" and msg.address >= 0 and msg.address <= 31 and type(msg.data) == "string" then

--- a/movestone.lua
+++ b/movestone.lua
@@ -25,7 +25,6 @@ local function checkprotection(pos,player)
 end
 
 local function move(pos,dir,state)
-	local newpos = vector.add(pos,dir)
 	local stack = mesecon.mvps_get_stack(pos,dir,state.maxstack,state.sticky and state.allsticky)
 	if not stack then
 		abortmovement(pos)
@@ -37,6 +36,7 @@ local function move(pos,dir,state)
 			return false
 		end
 	end
+	--luacheck: no redefined
 	local success,stack,oldstack = mesecon.mvps_push(pos,dir,state.maxstack)
 	if not success then
 		abortmovement(pos)
@@ -49,6 +49,7 @@ local function move(pos,dir,state)
 	end
 	if not state.sticky then return true end
 	local ppos = vector.add(pos,vector.multiply(dir,-1))
+	--luacheck: no unused, no redefined
 	local success,stack,oldstack
 	if state.allsticky then
 		success,stack,oldstack = mesecon.mvps_pull_all(ppos,dir,state.maxstack)
@@ -167,7 +168,6 @@ minetest.register_node("digistuff:movestone", {
 					if type(msg) ~= "table" or not msg.command then return end
 					if msg.command == "getstate" then
 						local ret = {}
-						local meta = minetest.get_meta(pos)
 						local state = meta:get_string("state")
 						if state ~= "" then state = minetest.deserialize(state) else state = {} end
 						if not state then
@@ -179,8 +179,6 @@ minetest.register_node("digistuff:movestone", {
 						ret.moveaxis = state.moveaxis
 						digilines.receptor_send(pos,rules,channel,ret)
 					elseif msg.command == "absmove" then
-						local ret = {}
-						local meta = minetest.get_meta(pos)
 						local state = meta:get_string("state")
 						if state ~= "" then state = minetest.deserialize(state) else state = {} end
 						if not state then
@@ -221,8 +219,6 @@ minetest.register_node("digistuff:movestone", {
 							minetest.get_node_timer(pos):start(0.1)
 						end
 					elseif msg.command == "relmove" then
-						local ret = {}
-						local meta = minetest.get_meta(pos)
 						local state = meta:get_string("state")
 						if state ~= "" then state = minetest.deserialize(state) else state = {} end
 						if not state then

--- a/movestone.lua
+++ b/movestone.lua
@@ -177,7 +177,7 @@ minetest.register_node("digistuff:movestone", {
 						ret.pos = pos
 						ret.targetpos = vector.new(state.targetx,state.targety,state.targetz)
 						ret.moveaxis = state.moveaxis
-						digiline:receptor_send(pos,rules,channel,ret)
+						digilines.receptor_send(pos,rules,channel,ret)
 					elseif msg.command == "absmove" then
 						local ret = {}
 						local meta = minetest.get_meta(pos)

--- a/nbsounds.lua
+++ b/nbsounds.lua
@@ -59,7 +59,7 @@ local mod_sounds = {
 		homedecor_book_close = "homedecor_book_close",
 		homedecor_door_close = "homedecor_door_close",
 		homedecor_door_open = "homedecor_door_open",
-		homedecor_gate = "homedecor_gate_open_close",		
+		homedecor_gate = "homedecor_gate_open_close",
 	},
 	homedecor_bathroom = {
 		homedecor_shower = "homedecor_shower",

--- a/nic.lua
+++ b/nic.lua
@@ -56,7 +56,7 @@ minetest.register_node("digistuff:nic", {
 						user_agent = "Minetest Digilines Modem",
 						},
 						function(res)
-							digiline:receptor_send(pos, digiline.rules.default, channel, res)
+							digilines.receptor_send(pos, digilines.rules.default, channel, res)
 						end)
 				end
 		},

--- a/nic.lua
+++ b/nic.lua
@@ -42,8 +42,7 @@ minetest.register_node("digistuff:nic", {
 		local meta = minetest.get_meta(pos)
 		if fields.channel then meta:set_string("channel",fields.channel) end
 	end,
-	digiline = 
-	{
+	digiline = {
 		receptor = {},
 		effector = {
 			action = function(pos,node,channel,msg)

--- a/noteblock.lua
+++ b/noteblock.lua
@@ -44,7 +44,7 @@ minetest.register_node("digistuff:noteblock", {
 						for i in pairs(validnbsounds) do
 							table.insert(soundnames,i)
 						end
-						digiline:receptor_send(pos, digiline.rules.default, channel, soundnames)
+						digilines.receptor_send(pos, digilines.rules.default, channel, soundnames)
 						return
 					end
 					if type(msg) == "string" then

--- a/panel.lua
+++ b/panel.lua
@@ -44,42 +44,42 @@ digistuff.panel_on_receive_fields = function(pos, formname, fields, sender)
 		end
 	elseif fields.up then
 		if can_bypass or not is_protected or not locked then
-			digiline:receptor_send(pos, digiline.rules.default, setchan, "up")
+			digilines.receptor_send(pos, digilines.rules.default, setchan, "up")
 		else
 			minetest.record_protection_violation(pos,playername)
 			minetest.chat_send_player(playername,"You are not authorized to use this panel.")
 		end
 	elseif fields.down then
 		if can_bypass or not is_protected or not locked then
-			digiline:receptor_send(pos, digiline.rules.default, setchan, "down")
+			digilines.receptor_send(pos, digilines.rules.default, setchan, "down")
 		else
 			minetest.record_protection_violation(pos,playername)
 			minetest.chat_send_player(playername,"You are not authorized to use this panel.")
 		end
 	elseif fields.left then
 		if can_bypass or not is_protected or not locked then
-			digiline:receptor_send(pos, digiline.rules.default, setchan, "left")
+			digilines.receptor_send(pos, digilines.rules.default, setchan, "left")
 		else
 			minetest.record_protection_violation(pos,playername)
 			minetest.chat_send_player(playername,"You are not authorized to use this panel.")
 		end
 	elseif fields.right then
 		if can_bypass or not is_protected or not locked then
-			digiline:receptor_send(pos, digiline.rules.default, setchan, "right")
+			digilines.receptor_send(pos, digilines.rules.default, setchan, "right")
 		else
 			minetest.record_protection_violation(pos,playername)
 			minetest.chat_send_player(playername,"You are not authorized to use this panel.")
 		end
 	elseif fields.back then
 		if can_bypass or not is_protected or not locked then
-			digiline:receptor_send(pos, digiline.rules.default, setchan, "back")
+			digilines.receptor_send(pos, digilines.rules.default, setchan, "back")
 		else
 			minetest.record_protection_violation(pos,playername)
 			minetest.chat_send_player(playername,"You are not authorized to use this panel.")
 		end
 	elseif fields.enter then
 		if can_bypass or not is_protected or not locked then
-			digiline:receptor_send(pos, digiline.rules.default, setchan, "enter")
+			digilines.receptor_send(pos, digilines.rules.default, setchan, "enter")
 		else
 			minetest.record_protection_violation(pos,playername)
 			minetest.chat_send_player(playername,"You are not authorized to use this panel.")

--- a/panel.lua
+++ b/panel.lua
@@ -135,10 +135,9 @@ minetest.register_node("digistuff:panel", {
 		fixed = {
 			{ -0.5, -0.5, 0.4, 0.5, 0.5, 0.5 }
 		}
-    	},
+	},
 	on_receive_fields = digistuff.panel_on_receive_fields,
-	digiline = 
-	{
+	digiline = {
 		receptor = {},
 		effector = {
 			action = digistuff.panel_on_digiline_receive

--- a/piston.lua
+++ b/piston.lua
@@ -38,6 +38,7 @@ local function retract(pos,node,max,allsticky,sound)
 	minetest.check_for_falling(ppos)
 	if type(max) ~= "number" or max <= 0 then return end
 	local pullpos = vector.add(pos,vector.multiply(actiondir,2))
+	--luacheck: no unused
 	local success,stack,oldstack
 	if allsticky then
 		success,stack,oldstack = mesecon.mvps_pull_all(pullpos,facedir,max)

--- a/switches.lua
+++ b/switches.lua
@@ -16,7 +16,7 @@ digistuff.button_push = function(pos,node,player)
 	local meta = minetest.get_meta(pos)
 	if meta:get_int("protected") == 1 and not digistuff.check_protection(pos,player) then return end
 	local mlight = meta:get_int("mlight") == 1
-	digiline:receptor_send(pos, digistuff.button_get_rules(node), meta:get_string("channel"), meta:get_string("msg"))
+	digilines.receptor_send(pos, digistuff.button_get_rules(node), meta:get_string("channel"), meta:get_string("msg"))
 	local newnode = "digistuff:button_on_pushed"
 	if meta:get_int("mlight") == 1 and (node.name == "digistuff:button_off" or node.name == "digistuff:button_off_pushed") then newnode = "digistuff:button_off_pushed" end
 	if node.name ~= newnode then minetest.swap_node(pos, {name = newnode, param2=node.param2}) end
@@ -417,7 +417,7 @@ minetest.register_node("digistuff:wall_knob_configured", {
 		value = full and max or math.min(max,value+1)
 		meta:set_int("value",value)
 		meta:set_string("infotext",string.format("Current setting: %d\nLeft-click to turn down or right-click to turn up",math.floor(tonumber(value))))
-		digiline:receptor_send(pos,digistuff.button_get_rules(node),meta:get_string("channel"),value)
+		digilines.receptor_send(pos,digistuff.button_get_rules(node),meta:get_string("channel"),value)
 	end,
 	on_punch = function(pos,node,player)
 		local meta = minetest.get_meta(pos)
@@ -428,7 +428,7 @@ minetest.register_node("digistuff:wall_knob_configured", {
 		value = full and min or math.max(min,value-1)
 		meta:set_int("value",value)
 		meta:set_string("infotext",string.format("Current setting: %d\nLeft-click to turn down or right-click to turn up",math.floor(tonumber(value))))
-		digiline:receptor_send(pos,digistuff.button_get_rules(node),meta:get_string("channel"),value)
+		digilines.receptor_send(pos,digistuff.button_get_rules(node),meta:get_string("channel"),value)
 	end,
 	sounds = default and default.node_sound_stone_defaults(),
 })

--- a/switches.lua
+++ b/switches.lua
@@ -190,13 +190,12 @@ minetest.register_node("digistuff:button_off_pushed", {
 	},
 	node_box = {
 	type = "fixed",
-	fixed = {
-		{ -6/16, -6/16,  6/16, 6/16, 6/16, 8/16 },
-		{ -4/16, -2/16, 11/32, 4/16, 2/16, 6/16 }
-	}
-    	},
-	digiline =
-	{
+		fixed = {
+			{ -6/16, -6/16,  6/16, 6/16, 6/16, 8/16 },
+			{ -4/16, -2/16, 11/32, 4/16, 2/16, 6/16 }
+		}
+	},
+	digiline = {
 		receptor = {},
 		wire = {
 			rules = digistuff.button_get_rules,
@@ -285,13 +284,12 @@ minetest.register_node("digistuff:button_on_pushed", {
 	_digistuff_channelcopier_fieldname = "channel",
 	node_box = {
 	type = "fixed",
-	fixed = {
-		{ -6/16, -6/16,  6/16, 6/16, 6/16, 8/16 },
-		{ -4/16, -2/16, 11/32, 4/16, 2/16, 6/16 }
-	}
-    	},
-	digiline =
-	{
+		fixed = {
+			{ -6/16, -6/16,  6/16, 6/16, 6/16, 8/16 },
+			{ -4/16, -2/16, 11/32, 4/16, 2/16, 6/16 }
+		}
+	},
+	digiline = {
 		receptor = {},
 		wire = {
 			rules = digistuff.button_get_rules,
@@ -436,8 +434,8 @@ minetest.register_node("digistuff:wall_knob_configured", {
 minetest.register_craft({
 	output = "digistuff:wall_knob",
 	recipe = {
-		{"",                           "mesecons_button:button_off",               ""},
+		{"", "mesecons_button:button_off", ""},
 		{"digilines:wire_std_00000000","mesecons_luacontroller:luacontroller0000", "digilines:wire_std_00000000"},
-		{"",                           "digilines:wire_std_00000000",              ""},
+		{"", "digilines:wire_std_00000000", ""},
 	},
 })

--- a/switches.lua
+++ b/switches.lua
@@ -15,7 +15,6 @@ end
 digistuff.button_push = function(pos,node,player)
 	local meta = minetest.get_meta(pos)
 	if meta:get_int("protected") == 1 and not digistuff.check_protection(pos,player) then return end
-	local mlight = meta:get_int("mlight") == 1
 	digilines.receptor_send(pos, digistuff.button_get_rules(node), meta:get_string("channel"), meta:get_string("msg"))
 	local newnode = "digistuff:button_on_pushed"
 	if meta:get_int("mlight") == 1 and (node.name == "digistuff:button_off" or node.name == "digistuff:button_off_pushed") then newnode = "digistuff:button_off_pushed" end

--- a/timer.lua
+++ b/timer.lua
@@ -44,7 +44,7 @@ minetest.register_node("digistuff:timer", {
 	on_timer = function(pos)
 		local meta = minetest.get_meta(pos)
 		local channel = meta:get_string("channel")
-		digiline:receptor_send(pos,digiline.rules.default,channel,"done")
+		digilines.receptor_send(pos,digilines.rules.default,channel,"done")
 		local loop = meta:get_int("loop") > 0
 		return loop
 	end,

--- a/timer.lua
+++ b/timer.lua
@@ -48,8 +48,7 @@ minetest.register_node("digistuff:timer", {
 		local loop = meta:get_int("loop") > 0
 		return loop
 	end,
-	digiline = 
-	{
+	digiline = {
 		receptor = {},
 		effector = {
 			action = function(pos,node,channel,msg)
@@ -69,7 +68,7 @@ minetest.register_node("digistuff:timer", {
 				end
 		},
 	},
-	
+
 })
 minetest.register_craft({
 	output = "digistuff:timer 2",

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -76,7 +76,7 @@ digistuff.ts_on_receive_fields = function (pos, formname, fields, sender)
 		end
 	else
 		fields.clicker = sender:get_player_name()
-		digiline:receptor_send(pos, digiline.rules.default, setchan, fields)
+		digilines.receptor_send(pos, digilines.rules.default, setchan, fields)
 	end
 end
 

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -92,7 +92,7 @@ digistuff.process_command = function (meta, data, msg)
 			end
 		end
 		if not msg.texture_name or type(msg.texture_name) ~= "string" then
-			return	
+			return
 		end
 		local field = {type="image",X=msg.X,Y=msg.Y,W=msg.W,H=msg.H,texture_name=minetest.formspec_escape(msg.texture_name)}
 		table.insert(data,field)
@@ -142,7 +142,7 @@ digistuff.process_command = function (meta, data, msg)
 			end
 		end
 		if not msg.label or type(msg.label) ~= "string" then
-			return	
+			return
 		end
 		local field = {type="label",X=msg.X,Y=msg.Y,label=minetest.formspec_escape(msg.label)}
 		table.insert(data,field)
@@ -153,7 +153,7 @@ digistuff.process_command = function (meta, data, msg)
 			end
 		end
 		if not msg.label or type(msg.label) ~= "string" then
-			return	
+			return
 		end
 		local field = {type="vertlabel",X=msg.X,Y=msg.Y,label=minetest.formspec_escape(msg.label)}
 		table.insert(data,field)
@@ -289,15 +289,14 @@ minetest.register_node("digistuff:touchscreen", {
 		fixed = {
 			{ -0.5, -0.5, 0.4, 0.5, 0.5, 0.5 }
 		}
-    	},
-    	_digistuff_channelcopier_fieldname = "channel",
+	},
+	_digistuff_channelcopier_fieldname = "channel",
 	_digistuff_channelcopier_onset = function(pos)
 		minetest.get_meta(pos):set_int("init",1)
 		digistuff.update_ts_formspec(pos)
 	end,
 	on_receive_fields = digistuff.ts_on_receive_fields,
-	digiline = 
-	{
+	digiline = {
 		receptor = {},
 		effector = {
 			action = digistuff.ts_on_digiline_receive


### PR DESCRIPTION
Adds luacheck config and workflow, and fixes most warnings, except for long lines and some redefined and unused variables in `piston.lua` and `movestone.lua`.

Note: squash this when merging.