### PR TITLE
add nic option config for json response

### DIFF
--- a/docs/nic.txt
+++ b/docs/nic.txt
@@ -1,2 +1,48 @@
 How to use the NIC:
 Send a digilines signal with the URL you want to download. The HTTPRequestResult table will be sent back on the same channel.
+
+# Examples
+
+## GET request with a plain url
+```lua
+-- request
+digiline_send("nic", "http://example.com")
+-- response
+event.msg = {
+	code = 200,
+	succeeded = true,
+	data = "<html></html>"
+}
+```
+
+## GET request with headers
+```lua
+-- request
+digiline_send("nic", {
+	url = "http://example.com",
+	headers = {"Accept: text/plain"}
+})
+-- response
+event.msg = {
+	code = 200,
+	succeeded = true,
+	data = "blah"
+}
+```
+
+## GET request with parsed json response
+```lua
+-- request
+digiline_send("nic", {
+	url = "http://example.com",
+	parse_json = true
+})
+-- response
+event.msg = {
+	code = 200,
+	succeeded = true,
+	data = {
+		my = "data"
+	}
+}
+```

--- a/docs/nic.txt
+++ b/docs/nic.txt
@@ -15,21 +15,6 @@ event.msg = {
 }
 ```
 
-## GET request with headers
-```lua
--- request
-digiline_send("nic", {
-	url = "http://example.com",
-	headers = {"Accept: text/plain"}
-})
--- response
-event.msg = {
-	code = 200,
-	succeeded = true,
-	data = "blah"
-}
-```
-
 ## GET request with parsed json response
 ```lua
 -- request

--- a/nic.lua
+++ b/nic.lua
@@ -49,7 +49,6 @@ minetest.register_node("digistuff:nic", {
 					local meta = minetest.get_meta(pos)
 					if meta:get_string("channel") ~= channel then return end
 					local url
-					local headers
 					local parse_json = false
 					-- parse message
 					if type(msg) == "string" then
@@ -58,7 +57,6 @@ minetest.register_node("digistuff:nic", {
 					elseif type(msg) == "table" and type(msg.url) == "string" then
 						-- config object
 						url = msg.url
-						headers = msg.headers
 						parse_json = msg.parse_json
 					else
 						-- not supported
@@ -67,8 +65,7 @@ minetest.register_node("digistuff:nic", {
 					http.fetch({
 							url = url,
 							timeout = 5,
-							user_agent = "Minetest Digilines Modem",
-							extra_headers = headers
+							user_agent = "Minetest Digilines Modem"
 						},
 						function(res)
 							if type(res.data) == "string" and parse_json then

--- a/nic.lua
+++ b/nic.lua
@@ -48,13 +48,33 @@ minetest.register_node("digistuff:nic", {
 			action = function(pos,node,channel,msg)
 					local meta = minetest.get_meta(pos)
 					if meta:get_string("channel") ~= channel then return end
-					if type(msg) ~= "string" then return end
+					local url
+					local headers
+					local parse_json = false
+					-- parse message
+					if type(msg) == "string" then
+						-- simple string data
+						url = msg
+					elseif type(msg) == "table" and type(msg.url) == "string" then
+						-- config object
+						url = msg.url
+						headers = msg.headers
+						parse_json = msg.parse_json
+					else
+						-- not supported
+						return
+					end
 					http.fetch({
-						url = msg,
-						timeout = 5,
-						user_agent = "Minetest Digilines Modem",
+							url = url,
+							timeout = 5,
+							user_agent = "Minetest Digilines Modem",
+							extra_headers = headers
 						},
 						function(res)
+							if type(res.data) == "string" and parse_json then
+								-- parse json data and replace payload
+								res.data = minetest.parse_json(res.data)
+							end
 							digilines.receptor_send(pos, digilines.rules.default, channel, res)
 						end)
 				end


### PR DESCRIPTION
This PR adds the ability to pass a config object to the nic as well as json parsing ~~and header settings.~~
The message can still be a plain url as text or an object in the form:

```lua
{
 url = "http://x.y",
 parse_json = true
)
```

I've tested it and it works well but there may be some crash vectors, not sure :shrug: 

## Example

Luacontroller
```lua
if event.type == "program" then
 digiline_send("nic", {
  url = "http://api.icndb.com/jokes/random",
  parse_json = true
 })
end

if event.type == "digiline" then
 print(event.msg)
end
```

Console
```lua
{
	completed = true,
	timeout = false,
	succeeded = true,
	data = {
		value = {
			id = 34,
			categories = {
				
			},
			joke = "The opening scene of the movie &quot;Saving Private Ryan&quot; is loosely based on games of dodgeball Chuck Norris played in second grade."
		},
		type = "success"
	},
	code = 200
}
```