### PR TITLE
Touchscreen rewrite

### DIFF
--- a/docs/touchscreen.md
+++ b/docs/touchscreen.md
@@ -136,6 +136,8 @@ These elements, for design or other reasons, are not supported by the touchscree
 
 Example code for each of the supported formspec elements. For more details see the [Minetest Lua API](https://github.com/minetest/minetest/blob/master/doc/lua_api.txt).
 
+All values except `command` and `element` are optional, with default values being used when a value is nil or invalid.
+
 **`tooltip`**
 
 ```lua

--- a/docs/touchscreen.md
+++ b/docs/touchscreen.md
@@ -8,6 +8,21 @@ The touchscreen is designed to be a customizable interface for input and display
 
 ## Commands
 
+**`set`** - Changes settings.
+
+```lua
+digiline_send("touchscreen", {
+	command = "set",
+	locked = false,
+	no_prepend = false,
+	real_coordinates = false,
+	fixed_size = false,
+	width = 10,
+	height = 8,
+	focus = "<name>",
+})
+```
+
 **`add`** - Adds an element, appending it after other elements.
 
 ```lua
@@ -46,18 +61,11 @@ digiline_send("touchscreen", {
 })
 ```
 
-**`set`** - Changes settings.
+**`clear`** - Removes all elements, but keeps settings.
 
 ```lua
 digiline_send("touchscreen", {
-	command = "set",
-	locked = false,
-	no_prepend = false,
-	real_coordinates = false,
-	fixed_size = false,
-	width = 10,
-	height = 8,
-	focus = "<name>",
+	command = "clear",
 })
 ```
 

--- a/docs/touchscreen.md
+++ b/docs/touchscreen.md
@@ -209,7 +209,7 @@ digiline_send("touchscreen", {
 	H = 2,
 	name = "model",
 	mesh = "character.b3d",
-	textures = character.png,
+	textures = {character.png},
 	rotation_x = 0,
 	rotation_y = 0,
 	continuous = false,
@@ -355,7 +355,7 @@ digiline_send("touchscreen", {
 	W = 4,
 	H = 3,
 	name = "hypertext",
-	text = "<b>hypertext</b>",
+	text = "<i>hypertext</i>",
 })
 ```
 
@@ -578,7 +578,7 @@ digiline_send("touchscreen", {
 	border = true,
 	highlight = "#466432",
 	highlight_text = "#ffffff",
-	open_depth = 0,
+	opendepth = 0,
 	columns = {
 		{type = "text", align = "center"},
 	},

--- a/docs/touchscreen.md
+++ b/docs/touchscreen.md
@@ -587,12 +587,12 @@ digiline_send("touchscreen", {
 
 **`item_grid`**
 
-`W` and `H` are the size of the grid in number of items.
-`name` is a prefix for the buttons, which are numbered with their index. (e.g. `grid_1`, `grid_2`, ...)
-`size` is the size of the buttons. Used for width and height.
-`spacing` is the space between buttons. Used for vertical and horizontal spacing.
-`interactable` determines whether buttons or images are used.
-`offset` is for paginating the list of items.
+- `W` and `H` are the size of the grid in number of items.
+- `name` is a prefix for the buttons, which are numbered with their index. (e.g. `grid_1`, `grid_2`, ...)
+- `size` is the size of the buttons. Used for width and height.
+- `spacing` is the space between buttons. Used for vertical and horizontal spacing.
+- `interactable` determines whether buttons or images are used.
+- `offset` is for paginating the list of items.
 
 ```lua
 digiline_send("touchscreen", {

--- a/docs/touchscreen.md
+++ b/docs/touchscreen.md
@@ -5,6 +5,7 @@ The touchscreen is designed to be a customizable interface for input and display
 - [Commands](#commands)
 - [Supported formspec elements](#supported-formspec-elements)
 - [Unsupported formspec elements](#unsupported-formspec-elements)
+- [Formspec element reference](#formspec-element-reference)
 
 ## Commands
 
@@ -110,12 +111,9 @@ digiline_send("touchscreen", {
 
 **Special elements:**
 
-- `tooltip_area`
-  Separate element for the alternate syntax of `tooltip`.
-- `table`
-  Combination of `table`, `tableoptions` and `tablecolumns`.
-- `item_grid`
-  Helper for displaying a grid of item buttons or images.
+- `tooltip_area` - Separate element for the alternate syntax of `tooltip`.
+- `table` - Combination of `table`, `tableoptions` and `tablecolumns`.
+- `item_grid` - Helper for displaying a grid of item buttons or images.
 
 ## Unsupported formspec elements
 
@@ -133,3 +131,484 @@ These elements, for design or other reasons, are not supported by the touchscree
 - `list`
 - `listring`
 - `listcolors`
+
+## Formspec element reference
+
+Example code for each of the supported formspec elements. For more details see the [Minetest Lua API](https://github.com/minetest/minetest/blob/master/doc/lua_api.txt).
+
+**`tooltip`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "tooltip",
+	element_name = "button",
+	tooltip_text = "tooltip",
+	bgcolor = "#303030",
+	fontcolor = "#ffffff",
+})
+```
+
+**`tooltip_area`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "tooltip_area",
+	X = 0,
+	Y = 0,
+	W = 100,
+	H = 100,
+	tooltip_text = "tooltip area",
+	bgcolor = "#303030",
+	fontcolor = "#ffffff",
+})
+```
+
+**`image`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "image",
+	X = 0,
+	Y = 0,
+	W = 1,
+	H = 1,
+	texture_name = "default_dirt.png",
+})
+```
+
+**`animated_image`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "animated_image",
+	X = 0,
+	Y = 0,
+	W = 1,
+	H = 1,
+	name = "animated_image",
+	texture_name = "default_lava_flowing_animated.png",
+	frame_count = 16,
+	frame_duration = 200,
+	frame_start = 1,
+})
+```
+
+**`model`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "model",
+	X = 0,
+	Y = 0,
+	W = 2,
+	H = 2,
+	name = "model",
+	mesh = "character.b3d",
+	textures = character.png,
+	rotation_x = 0,
+	rotation_y = 0,
+	continuous = false,
+	mouse_control = true,
+})
+```
+
+**`item_image`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "item_image",
+	X = 0,
+	Y = 0,
+	W = 1,
+	H = 1,
+	item_name = "default:dirt_with_grass",
+})
+```
+
+**`bgcolor`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "bgcolor",
+	bgcolor = "#ffffff",
+	fullscreen = false,
+	fbgcolor = "",
+})
+```
+
+**`background`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "background",
+	X = 0,
+	Y = 0,
+	W = 0,
+	H = 0,
+	texture_name = "digistuff_ts_bg.png",
+	auto_clip = true,
+})
+```
+
+**`background9`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "background9",
+	X = 0,
+	Y = 0,
+	W = 0,
+	H = 0,
+	texture_name = "digistuff_ts_bg.png",
+	auto_clip = true,
+	middle = 3,
+})
+```
+
+**`pwdfield`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "pwdfield",
+	X = 0,
+	Y = 0,
+	W = 3,
+	H = 0.8,
+	name = "pwdfield",
+	label = "",
+})
+```
+
+**`field`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "field",
+	X = 0,
+	Y = 0,
+	W = 3,
+	H = 0.8,
+	name = "field",
+	label = "field",
+	default = "",
+})
+```
+
+**`field_close_on_enter`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "field_close_on_enter",
+	name = "field",
+	close_on_enter = true,
+})
+```
+
+**`textarea`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "textarea",
+	X = 0,
+	Y = 0,
+	W = 4,
+	H = 3,
+	name = "textarea",
+	label = "",
+	default = "",
+})
+```
+
+**`label`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "label",
+	X = 0,
+	Y = 0,
+	label = "label",
+})
+```
+
+**`hypertext`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "hypertext",
+	X = 0,
+	Y = 0,
+	W = 4,
+	H = 3,
+	name = "hypertext",
+	text = "<b>hypertext</b>",
+})
+```
+
+**`vertlabel`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "vertlabel",
+	X = 0,
+	Y = 0,
+	label = "vertlabel",
+})
+```
+
+**`button`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "button",
+	X = 0,
+	Y = 0,
+	W = 3,
+	H = 0.8,
+	name = "button",
+	label = "button",
+})
+```
+
+**`image_button`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "image_button",
+	X = 0,
+	Y = 0,
+	W = 1,
+	H = 1,
+	texture_name = "default_stone_block.png",
+	name = "image_button",
+	label = "button",
+	noclip = true,
+	drawborder = true,
+	pressed_texture_name = "",
+})
+```
+
+**`item_image_button`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "item_image_button",
+	X = 0,
+	Y = 0,
+	W = 1,
+	H = 1,
+	item_name = "default:stone_block",
+	name = "item_image_button",
+	label = "",
+})
+```
+
+**`button_exit`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "button_exit",
+	X = 0,
+	Y = 0,
+	W = 3,
+	H = 0.8,
+	name = "button_exit",
+	label = "button",
+})
+```
+
+**`image_button_exit`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "image_button_exit",
+	X = 0,
+	Y = 0,
+	W = 1,
+	H = 1,
+	texture_name = "default_mese_block.png",
+	name = "image_button_exit",
+	label = "button",
+})
+```
+
+**`textlist`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "textlist",
+	X = 0,
+	Y = 0,
+	W = 4,
+	H = 3,
+	name = "textlist",
+	listelements = {"a", "b", "c"},
+	selected_id = 0,
+	transparent = false,
+})
+```
+
+**`tabheader`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "tabheader",
+	X = 0,
+	Y = 0,
+	name = "tabheader",
+	captions = {"a", "b", "c"},
+	current_tab = 0,
+	transparent = false,
+	draw_border = false,
+})
+```
+
+**`box`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "box",
+	X = 0,
+	Y = 0,
+	W = 1,
+	H = 1,
+	color = "#ffffff",
+})
+```
+
+**`dropdown`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "dropdown",
+	X = 0,
+	Y = 0,
+	W = 3,
+	H = 0.8,
+	name = "dropdown",
+	listelements = {"a", "b", "c"},
+	selected_id = 0,
+	index_event = false,
+})
+```
+
+**`checkbox`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "checkbox",
+	X = 0,
+	Y = 0,
+	name = "checkbox",
+	label = "checkbox",
+	selected = false,
+})
+```
+
+**`style`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "style",
+	selectors = {
+		"button_name",
+	},
+	properties = {
+		border = false,
+	},
+})
+```
+
+**`style_type`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "style_type",
+	selectors = {
+		"button",
+	},
+	properties = {
+		border = false,
+	},
+})
+```
+
+**`table`**
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "table",
+	X = 0,
+	Y = 0,
+	W = 4,
+	H = 3,
+	name = "table",
+	cells = {"a", "b", "c"},
+	selected_id = 0,
+	color = "#ffffff",
+	background = "#000000",
+	border = true,
+	highlight = "#466432",
+	highlight_text = "#ffffff",
+	open_depth = 0,
+	columns = {
+		{type = "text", align = "center"},
+	},
+})
+```
+
+**`item_grid`**
+
+`W` and `H` are the size of the grid in number of items.
+`name` is a prefix for the buttons, which are numbered with their index. (e.g. `grid_1`, `grid_2`, ...)
+`size` is the size of the buttons. Used for width and height.
+`spacing` is the space between buttons. Used for vertical and horizontal spacing.
+`interactable` determines whether buttons or images are used.
+`offset` is for paginating the list of items.
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "item_grid",
+	X = 0,
+	Y = 0,
+	W = 1,
+	H = 1,
+	name = "grid",
+	spacing = 0,
+	size = 1,
+	interactable = true,
+	items = {
+		"default:dirt 99",
+	},
+	offset = 1,
+})
+```

--- a/docs/touchscreen.md
+++ b/docs/touchscreen.md
@@ -1,0 +1,127 @@
+# Digilines Touchscreen
+
+The touchscreen is designed to be a customizable interface for input and display, it allows creating a custom formspec using a series of digiline commands, usually from a Luacontroller.
+
+- [Commands](#commands)
+- [Supported formspec elements](#supported-formspec-elements)
+- [Unsupported formspec elements](#unsupported-formspec-elements)
+
+## Commands
+
+**`add`** - Adds an element, appending it after other elements.
+
+```lua
+digiline_send("touchscreen", {
+	command = "add",
+	element = "<element>",
+})
+```
+
+**`insert`** - Adds an element at a specific index.
+
+```lua
+digiline_send("touchscreen", {
+	command = "insert",
+	index = 1,
+	element = "<element>",
+})
+```
+
+**`replace`** - Replaces an existing element.
+
+```lua
+digiline_send("touchscreen", {
+	command = "replace",
+	index = 1,
+	element = "<element>",
+})
+```
+
+**`remove`** - Removes an element.
+
+```lua
+digiline_send("touchscreen", {
+	command = "remove",
+	index = 1,
+})
+```
+
+**`set`** - Changes settings.
+
+```lua
+digiline_send("touchscreen", {
+	command = "set",
+	locked = false,
+	no_prepend = false,
+	real_coordinates = false,
+	fixed_size = false,
+	width = 10,
+	height = 8,
+	focus = "<name>",
+})
+```
+
+## Supported formspec elements
+
+**Standard elements:**
+
+- `tooltip`
+- `image`
+- `animated_image`
+- `model`
+- `item_image`
+- `bgcolor`
+- `background`
+- `background9`
+- `pwdfield`
+- `field`
+- `field_close_on_enter`
+- `textarea`
+- `label`
+- `hypertext`
+- `vertlabel`
+- `button`
+- `image_button`
+- `item_image_button`
+- `button_exit`
+- `image_button_exit`
+- `textlist`
+- `tabheader`
+- `box`
+- `dropdown`
+- `checkbox`
+- `style`
+- `style_type`
+
+**Elements as settings:**
+
+- `size`
+- `no_prepend`
+- `real_coordinates`
+- `set_focus`
+
+**Special elements:**
+
+- `tooltip_area`
+  Separate element for the alternate syntax of `tooltip`.
+- `table`
+  Combination of `table`, `tableoptions` and `tablecolumns`.
+- `item_grid`
+  Helper for displaying a grid of item buttons or images.
+
+## Unsupported formspec elements
+
+These elements, for design or other reasons, are not supported by the touchscreen:
+
+- `formspec_version`
+- `position`
+- `anchor`
+- `container`
+- `container_end`
+- `scroll_container`
+- `scroll_container_end`
+- `scrollbar`
+- `scrollbaroptions`
+- `list`
+- `listring`
+- `listcolors`

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -254,6 +254,67 @@ local formspec_elements = {
 	},
 }
 
+
+local valid_options = {
+	color = str,
+	background = str,
+	border = bool,
+	highlight = str,
+	highlight_text = str,
+	open_depth = num
+}
+
+local function column(value)
+	local t = str(value.type)
+	if not t then return end
+	local c = {t}
+	for k,v in pairs(value) do
+		if k ~= "type" then
+			if type(v) == "number" then
+				c[#c+1] = k.."="..num(v, "")
+			elseif type(v) == "string" then
+				c[#c+1] = k.."="..str(v, "")
+			end
+		end
+	end
+	return table.concat(c, ",")
+end
+
+formspec_elements.table = function(values)
+	local tbl = ""
+	local name = str(values.name, "table")
+	local cells = list(values.cells, "a,b,c")
+	for v,d in pairs({X = 0, Y = 0, W = 4, H = 3, selected_id = 0}) do
+		if type(values[v]) ~= "number" then
+			values[v] = d
+		end
+	end
+	local options = {}
+	for v,f in pairs(valid_options) do
+		local value = f(values[v])
+		if value ~= nil then
+			options[#options+1] = v.."="..value
+		end
+	end
+	if #options > 0 then
+		tbl = tbl.."tableoptions["..table.concat(options, ";").."]"
+	end
+	local columns = {}
+	if type(values.columns) == "table" then
+		for _,c in ipairs(values.columns) do
+			if type(c) == "table" then
+				columns[#columns+1] = column(c)
+			end
+		end
+	end
+	if #columns > 0 then
+		tbl = tbl.."tablecolumns["..table.concat(columns, ";").."]"
+	end
+	return tbl..string.format("table[%s,%s;%s,%s;%s;%s;%s]",
+		values.X, values.Y, values.W, values.H, name, cells, values.selected_id)
+end
+
+
 formspec_elements.item_grid = function(values)
 	if values.interactable ~= false then
 		values.name = str(values.name, "grid").."_"

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -2,12 +2,12 @@
 -- `minetest.formspec_escape` with option to not escape commas
 local function fs_escape(text, is_list)
 	if text ~= nil then
-		text = text:gsub("\\", "\\\\")
-		text = text:gsub("%]", "\\]")
-		text = text:gsub("%[", "\\[")
-		text = text:gsub(";", "\\;")
+		text = string.gsub(text, "\\", "\\\\")
+		text = string.gsub(text, "%]", "\\]")
+		text = string.gsub(text, "%[", "\\[")
+		text = string.gsub(text, ";", "\\;")
 		if not is_list then
-			text = text:gsub(",", "\\,")
+			text = string.gsub(text, ",", "\\,")
 		end
 	end
 	return text
@@ -44,7 +44,7 @@ local function list(value, default_value)
 	local new_list = {}
 	for _,v in ipairs(value) do
 		if type(v) == "string" then
-			new_list[#new_list+1] = fs_escape(v)
+			table.insert(new_list, fs_escape(v))
 		end
 	end
 	if #new_list < 1 then
@@ -60,8 +60,8 @@ local function middle(value, default_value)  -- Only for `background9`
 	if type(value) ~= "string" then
 		return default_value
 	end
-	if value:match("^%-?%d+$") or value:match("^%-?%d+,%-?%d+$")
-			or value:match("^%-?%d+,%-?%d+,%-?%d+,%-?%d+$") then
+	if string.match(value, "^%-?%d+$") or string.match(value, "^%-?%d+,%-?%d+$")
+			or string.match(value, "^%-?%d+,%-?%d+,%-?%d+,%-?%d+$") then
 		return value
 	end
 	return default_value
@@ -87,11 +87,11 @@ local function prop(value, default_value)  -- Only for `stlye` and `style_type`
 		if type(k) == "string" then
 			k = fs_escape(k).."="
 			if type(v) == "string" then
-				new_prop[#new_prop+1] = k..fs_escape(v, true)
+				table.insert(new_prop, k..fs_escape(v, true))
 			elseif type(v) == "number" then
-				new_prop[#new_prop+1] = k..string.format("%.4g", v)
+				table.insert(new_prop, k..string.format("%.4g", v))
 			elseif type(v) == "boolean" then
-				new_prop[#new_prop+1] = k..(v and "true" or "false")
+				table.insert(new_prop, k..(v and "true" or "false"))
 			end
 		end
 	end
@@ -286,18 +286,18 @@ local function column(value)
 	if type(value) ~= "table" or type(value.type) ~= "string" then
 		return
 	end
-	local c = {str(value.type)}
+	local new_column = {str(value.type)}
 	for k,v in pairs(value) do
 		if type(k) == "string" and k ~= "type" then
 			k = fs_escape(k).."="
 			if type(v) == "string" then
-				c[#c+1] = k..fs_escape(v, true)
+				table.insert(new_column, k..fs_escape(v, true))
 			elseif type(v) == "number" then
-				c[#c+1] = k..string.format("%.4g", v)
+				table.insert(new_column, k..string.format("%.4g", v))
 			end
 		end
 	end
-	return table.concat(c, ",")
+	return table.concat(new_column, ",")
 end
 
 formspec_elements.table = function(values)
@@ -313,7 +313,7 @@ formspec_elements.table = function(values)
 	for v,f in pairs(table_options) do
 		local value = f(values[v])
 		if value ~= nil then
-			options[#options+1] = v.."="..value
+			table.insert(options, v.."="..value)
 		end
 	end
 	if #options > 0 then
@@ -322,7 +322,7 @@ formspec_elements.table = function(values)
 	local columns = {}
 	if type(values.columns) == "table" then
 		for _,v in ipairs(values.columns) do
-			columns[#columns+1] = column(v, true)
+			table.insert(columns, column(v, true))
 		end
 	end
 	if #columns > 0 then
@@ -352,7 +352,7 @@ formspec_elements.item_grid = function(values)
 			if type(item) ~= "string" then
 				return table.concat(grid)
 			end
-			item = item:match("^[^ %[%]\\,;]* ?%d* ?%d*")
+			item = string.match(item, "^[^ %[%]\\,;]* ?%d* ?%d*")
 			if values.interactable ~= false then
 				grid[n] = string.format("item_image_button[%s,%s;%s,%s;%s;%s;]",
 					x, y, values.size, values.size, item, values.name..n)

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -13,6 +13,13 @@ local function str(value, default_value)
 	return minetest.formspec_escape(value)
 end
 
+local function bool(value, default_value)
+	if type(value) ~= "boolean" then
+		return default_value
+	end
+	return value and "true" or "false"
+end
+
 local function list(value, default_value)
 	if type(value) ~= "table" or #value < 1 then
 		return default_value
@@ -27,16 +34,6 @@ local function list(value, default_value)
 		return default_value
 	end
 	return table.concat(new_list, ",")
-end
-
-local function bool(value, default_value)
-	if type(value) ~= "boolean" then
-		if value == "true" or value == "false" then
-			return value
-		end
-		return default_value
-	end
-	return value and "true" or "false"
 end
 
 local function middle(value, default_value)  -- Only for `background9`
@@ -196,7 +193,7 @@ local formspec_elements = {
 		{num, num, num, num, str, str, str, bool, bool, str}
 	},
 	item_image_button = {
-		"image_button[%s,%s;%s,%s;%s;%s;%s]",
+		"item_image_button[%s,%s;%s,%s;%s;%s;%s]",
 		{"X", "Y", "W", "H", "item_name", "name", "label"},
 		{"0", "0", "1", "1", "default:stone_block", "item_image_button", ""},
 		{num, num, num, num, str, str, str}

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -83,7 +83,7 @@ local formspec_elements = {
 		{num, num, num, num, str}
 	},
 	background = {
-		"background[<X>,<Y>;<W>,<H>;<texture name>;<auto_clip>]",
+		"background[%s,%s;%s,%s;%s;%s]",
 		{"X", "Y", "W", "H", "texture_name", "auto_clip"},
 		{"0", "0", "0", "0", "digistuff_ts_bg.png", "true"},
 		{num, num, num, num, str, bool}
@@ -185,7 +185,7 @@ local formspec_elements = {
 		{num, num, num, num, str, list, num, bool}
 	},
 	checkbox = {
-		"checkbox[<X>,<Y>;<name>;<label>;<selected>]",
+		"checkbox[%s,%s;%s;%s;%s]",
 		{"X", "Y", "name", "label", "selected"},
 		{"0", "0", "checkbox", "checkbox", "false"},
 		{num, num, str, str, bool}

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -213,4 +213,22 @@ formspec_elements.background9 = {
 	{num, num, num, num, str, bool, middle}
 }
 
+local function fullscreen(value, default_value)
+	if type(value) == "boolean" then
+		return value and "true" or "false"
+	end
+	if value == "true" or value == "false"
+			or value == "both" or value == "neither" then
+		return value
+	end
+	return default_value
+end
+
+formspec_elements.bgcolor = {
+	"bgcolor[%s;%s;%s]",
+	{"bgcolor", "fullscreen", "fbgcolor"},
+	{"#ffffff", "", ""},
+	{str, fullscreen, str}
+}
+
 return formspec_elements

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -1,0 +1,195 @@
+
+local function num(value, default_value)
+	if type(value) ~= "number" then
+		return default_value
+	end
+	return string.format("%.4g", value)
+end
+
+local function str(value, default_value)
+	if type(value) ~= "string" then
+		return default_value
+	end
+	return minetest.formspec_escape(value)
+end
+
+local function list(value, default_value)
+	if type(value) ~= "table" then
+		if type(value) == "string" then
+			return minetest.formspec_escape(value)
+		end
+		return default_value
+	end
+	if #value < 1 then
+		return default_value
+	end
+	local new_list = {}
+	for _,v in ipairs(value) do
+		if type(v) == "string" then
+			new_list:insert(minetest.formspec_escape(v))
+		end
+	end
+	if #new_list < 1 then
+		return default_value
+	end
+	return new_list:concat(",")
+end
+
+local function bool(value, default_value)
+	if type(value) ~= "boolean" then
+		if value == "true" or value == "false" then
+			return value
+		end
+		return default_value
+	end
+	return value and "true" or "false"
+end
+
+local formspec_elements = {
+	tooltip = {
+		"tooltip[%s;%s;%s;%s]",
+		{"element_name", "tooltip_text", "bgcolor", "fontcolor"},
+		{"button", "tooltip", "#303030", "#ffffff"},
+		{str, str, str, str},
+	},
+	tooltip_area = {
+		"tooltip[%s;%s;%s;%s]",
+		{"X", "Y", "W", "H", "tooltip_text", "bgcolor", "fontcolor"},
+		{"0", "0", "100", "100", "tooltip area", "#303030", "#ffffff"},
+		{num, num, num, num, str, str, str},
+	},
+	image = {
+		"image[%s,%s;%s,%s;%s]",
+		{"X", "Y", "W", "H", "texture_name"},
+		{"0", "0", "1", "1", "default_dirt.png^default_grass_side.png"},
+		{num, num, num, num, str}
+	},
+	animated_image = {
+		"animated_image[%s,%s;%s,%s;%s;%s;%s;%s;%s]",
+		{"X", "Y", "W", "H", "name", "texture_name", "frame_count", "frame_duration", "frame_start"},
+		{"0", "0", "1", "1", "animated_image", "default_lava_flowing_animated.png", "16", "200", "1"},
+		{num, num, num, num, str, str, num, num, num}
+	},
+	model = {
+		"model[%s,%s;%s,%s;%s;%s;%s;%s,%s;%s;%s;]",
+		{"X", "Y", "W", "H", "name", "mesh", "textures", "rotation_x", "rotation_y", "continuous", "mouse_control"},
+		{"0", "0", "2", "2", "model", "torch_floor.obj", "default_torch_on_floor.png", "0", "0", "", ""},
+		{num, num, num, num, str, str, list, num, num, bool, bool}
+	},
+	item_image = {
+		"item_image[%s,%s;%s,%s;%s]",
+		{"X", "Y", "W", "H", "item_name"},
+		{"0", "0", "1", "1", "default:dirt_with_grass"},
+		{num, num, num, num, str}
+	},
+	background = {
+		"background[<X>,<Y>;<W>,<H>;<texture name>;<auto_clip>]",
+		{"X", "Y", "W", "H", "texture_name", "auto_clip"},
+		{"0", "0", "0", "0", "digistuff_ts_bg.png", "true"},
+		{num, num, num, num, str, bool}
+	},
+	pwdfield = {
+		"field[%s,%s;%s,%s;%s;%s]",
+		{"X", "Y", "W", "H", "name", "label"},
+		{"0", "0", "3", "0.8", "pwdfield", ""},
+		{num, num, num, num, str, str}
+	},
+	field = {
+		"field[%s,%s;%s,%s;%s;%s;%s]",
+		{"X", "Y", "W", "H", "name", "label", "default"},
+		{"0", "0", "3", "0.8", "field", "field", ""},
+		{num, num, num, num, str, str, str}
+	},
+	field_close_on_enter = {
+		"field_close_on_enter[%s;%s]",
+		{"name", "close_on_enter"},
+		{"field", "true"},
+		{str, bool}
+	},
+	textarea = {
+		"textarea[%s,%s;%s,%s;%s;%s;%s]",
+		{"X", "Y", "W", "H", "name", "label", "default"},
+		{"0", "0", "4", "3", "textarea", "", ""},
+		{num, num, num, num, str, str, str}
+	},
+	label = {
+		"label[%s,%s;%s]",
+		{"X", "Y", "label"},
+		{"0", "0", "label"},
+		{num, num, str}
+	},
+	hypertext = {
+		"hypertext[%s,%s;%s,%s;%s;%s]",
+		{"X", "Y", "W", "H", "name", "text"},
+		{"0", "0", "4", "3", "hypertext", "hypertext"},
+		{num, num, num, num, str, str}
+	},
+	vertlabel = {
+		"vertlabel[%s,%s;%s]",
+		{"X", "Y", "label"},
+		{"0", "0", "vertlabel"},
+		{num, num, str}
+	},
+	button = {
+		"button[%s,%s;%s,%s;%s;%s]",
+		{"X", "Y", "W", "H", "name", "label"},
+		{"0", "0", "3", "0.8", "button", "button"},
+		{num, num, num, num, str, str}
+	},
+	image_button = {
+		"image_button[%s,%s;%s,%s;%s;%s;%s;%s;%s;%s]",
+		{"X", "Y", "W", "H", "texture_name", "name", "label", "noclip", "drawborder", "pressed_texture_name"},
+		{"0", "0", "1", "1", "default_stone_block.png", "image_button", "button", "", "", ""},
+		{num, num, num, num, str, str, str, bool, bool, str}
+	},
+	item_image_button = {
+		"image_button[%s,%s;%s,%s;%s;%s;%s]",
+		{"X", "Y", "W", "H", "item_name", "name", "label"},
+		{"0", "0", "1", "1", "default:stone_block", "item_image_button", ""},
+		{num, num, num, num, str, str, str}
+	},
+	button_exit = {
+		"button_exit[%s,%s;%s,%s;%s;%s]",
+		{"X", "Y", "W", "H", "name", "label"},
+		{"0", "0", "3", "0.8", "button_exit", "button"},
+		{num, num, num, num, str, str}
+	},
+	image_button_exit = {
+		"image_button_exit[%s,%s;%s,%s;%s;%s;%s]",
+		{"X", "Y", "W", "H", "texture_name", "name", "label"},
+		{"0", "0", "1", "1", "default_mese_block.png", "image_button_exit", "button"},
+		{num, num, num, num, str, str, str}
+	},
+	textlist = {
+		"textlist[%s,%s;%s,%s;%s;%s;%s;%s]",
+		{"X", "Y", "W", "H", "name", "listelements", "selected_id", "transparent"},
+		{"0", "0", "4", "3", "textlist", "a,b,c", "0", "false"},
+		{num, num, num, num, str, list, num, bool}
+	},
+	tabheader = {
+		"tabheader[%s,%s;%s;%s;%s;%s;%s]",
+		{"X", "Y", "name", "captions", "current_tab", "transparent", "draw_border"},
+		{"0", "0", "tabheader", "a,b,c", "0", "false", "false"},
+		{num, num, str, list, num, bool, bool}
+	},
+	box = {
+		"box[%s,%s;%s,%s;%s]",
+		{"X", "Y", "W", "H", "color"},
+		{"0", "0", "1", "1", "#ffffff"},
+		{num, num, num, num, str}
+	},
+	dropdown = {
+		"dropdown[%s,%s;%s,%s;%s;%s,%s;%s;%s]",
+		{"X", "Y", "W", "H", "name", "listelements", "selected_id", "index_event"},
+		{"0", "0", "3", "0.8", "dropdown", "a,b,c", "0", "false"},
+		{num, num, num, num, str, list, num, bool}
+	},
+	checkbox = {
+		"checkbox[<X>,<Y>;<name>;<label>;<selected>]",
+		{"X", "Y", "name", "label", "selected"},
+		{"0", "0", "checkbox", "checkbox", "false"},
+		{num, num, str, str, bool}
+	},
+}
+
+return formspec_elements

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -225,4 +225,39 @@ formspec_elements.bgcolor = {
 	{str, fullscreen, str}
 }
 
+local function prop(value, default_value)
+	if type(value) ~= "table" or next(value) == nil then
+		return default_value
+	end
+	local new_prop = ""
+	for k,v in pairs(value) do
+		if type(k) == "string" then
+			k = minetest.formspec_escape(k).."="
+			local t = type(v)
+			if t == "string" then
+				table.insert(new_prop, k..minetest.formspec_escape(v))
+			elseif t == "number" then
+				table.insert(new_prop, k..string.format("%.4g", v))
+			elseif t == "boolean" then
+				table.insert(new_prop, k..(v and "true" or "false"))
+			end
+		end
+	end
+	return table.concat(new_prop, ";")
+end
+
+formspec_elements.style = {
+	"style[%s;%s]",
+	{"selectors", "properties"},
+	{"", ""},
+	{list, prop}
+}
+
+formspec_elements.style_type = {
+	"style_type[%s;%s]",
+	{"selectors", "properties"},
+	{"", ""},
+	{list, prop}
+}
+
 return formspec_elements

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -71,9 +71,9 @@ local formspec_elements = {
 		{num, num, num, num, str, str, num, num, num}
 	},
 	model = {
-		"model[%s,%s;%s,%s;%s;%s;%s;%s,%s;%s;%s;]",
+		"model[%s,%s;%s,%s;%s;%s;%s;%s,%s;%s;%s;0,0]",
 		{"X", "Y", "W", "H", "name", "mesh", "textures", "rotation_x", "rotation_y", "continuous", "mouse_control"},
-		{"0", "0", "2", "2", "model", "torch_floor.obj", "default_torch_on_floor.png", "0", "0", "", ""},
+		{"0", "0", "2", "2", "model", "character.b3d", "character.png", "0", "0", "", ""},
 		{num, num, num, num, str, str, list, num, num, bool, bool}
 	},
 	item_image = {

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -39,6 +39,53 @@ local function bool(value, default_value)
 	return value and "true" or "false"
 end
 
+local function middle(value, default_value)  -- Only for `background9`
+	local t = type(value)
+	if t == "number" then
+		return string.format("%i", value)
+	elseif t ~= "string" then
+		return default_value
+	end
+	if value:match("^%-?%d+$") or value:match("^%-?%d+,%-?%d+$")
+			or value:match("^%-?%d+,%-?%d+,%-?%d+,%-?%d+$") then
+		return value
+	end
+	return default_value
+end
+
+local function fullscreen(value, default_value)  -- Only for `bgcolor`
+	if type(value) == "boolean" then
+		return value and "true" or "false"
+	end
+	if value == "true" or value == "false"
+			or value == "both" or value == "neither" then
+		return value
+	end
+	return default_value
+end
+
+local function prop(value, default_value)  -- Only for `stlye` and `style_type`
+	if type(value) ~= "table" or next(value) == nil then
+		return default_value
+	end
+	local new_prop = ""
+	for k,v in pairs(value) do
+		if type(k) == "string" then
+			k = minetest.formspec_escape(k).."="
+			local t = type(v)
+			if t == "string" then
+				table.insert(new_prop, k..minetest.formspec_escape(v))
+			elseif t == "number" then
+				table.insert(new_prop, k..string.format("%.4g", v))
+			elseif t == "boolean" then
+				table.insert(new_prop, k..(v and "true" or "false"))
+			end
+		end
+	end
+	return table.concat(new_prop, ";")
+end
+
+
 local formspec_elements = {
 	tooltip = {
 		"tooltip[%s;%s;%s;%s]",
@@ -76,11 +123,23 @@ local formspec_elements = {
 		{"0", "0", "1", "1", "default:dirt_with_grass"},
 		{num, num, num, num, str}
 	},
+	bgcolor = {
+		"bgcolor[%s;%s;%s]",
+		{"bgcolor", "fullscreen", "fbgcolor"},
+		{"#ffffff", "", ""},
+		{str, fullscreen, str}
+	},
 	background = {
 		"background[%s,%s;%s,%s;%s;%s]",
 		{"X", "Y", "W", "H", "texture_name", "auto_clip"},
 		{"0", "0", "0", "0", "digistuff_ts_bg.png", "true"},
 		{num, num, num, num, str, bool}
+	},
+	background9 = {
+		"background9[%s,%s;%s,%s;%s;%s;%s]",
+		{"X", "Y", "W", "H", "texture_name", "auto_clip", "middle"},
+		{"0", "0", "0", "0", "digistuff_ts_bg.png", "true", "3"},
+		{num, num, num, num, str, bool, middle}
 	},
 	pwdfield = {
 		"field[%s,%s;%s,%s;%s;%s]",
@@ -184,80 +243,18 @@ local formspec_elements = {
 		{"0", "0", "checkbox", "checkbox", "false"},
 		{num, num, str, str, bool}
 	},
-}
-
-local function middle(value, default_value)
-	local t = type(value)
-	if t == "number" then
-		return string.format("%i", value)
-	elseif t ~= "string" then
-		return default_value
-	end
-	if value:match("^%-?%d+$") or value:match("^%-?%d+,%-?%d+$")
-			or value:match("^%-?%d+,%-?%d+,%-?%d+,%-?%d+$") then
-		return value
-	end
-	return default_value
-end
-
-formspec_elements.background9 = {
-	"background9[%s,%s;%s,%s;%s;%s;%s]",
-	{"X", "Y", "W", "H", "texture_name", "auto_clip", "middle"},
-	{"0", "0", "0", "0", "digistuff_ts_bg.png", "true", "3"},
-	{num, num, num, num, str, bool, middle}
-}
-
-local function fullscreen(value, default_value)
-	if type(value) == "boolean" then
-		return value and "true" or "false"
-	end
-	if value == "true" or value == "false"
-			or value == "both" or value == "neither" then
-		return value
-	end
-	return default_value
-end
-
-formspec_elements.bgcolor = {
-	"bgcolor[%s;%s;%s]",
-	{"bgcolor", "fullscreen", "fbgcolor"},
-	{"#ffffff", "", ""},
-	{str, fullscreen, str}
-}
-
-local function prop(value, default_value)
-	if type(value) ~= "table" or next(value) == nil then
-		return default_value
-	end
-	local new_prop = ""
-	for k,v in pairs(value) do
-		if type(k) == "string" then
-			k = minetest.formspec_escape(k).."="
-			local t = type(v)
-			if t == "string" then
-				table.insert(new_prop, k..minetest.formspec_escape(v))
-			elseif t == "number" then
-				table.insert(new_prop, k..string.format("%.4g", v))
-			elseif t == "boolean" then
-				table.insert(new_prop, k..(v and "true" or "false"))
-			end
-		end
-	end
-	return table.concat(new_prop, ";")
-end
-
-formspec_elements.style = {
-	"style[%s;%s]",
-	{"selectors", "properties"},
-	{"", ""},
-	{list, prop}
-}
-
-formspec_elements.style_type = {
-	"style_type[%s;%s]",
-	{"selectors", "properties"},
-	{"", ""},
-	{list, prop}
+	style = {
+		"style[%s;%s]",
+		{"selectors", "properties"},
+		{"", ""},
+		{list, prop}
+	},
+	style_type = {
+		"style_type[%s;%s]",
+		{"selectors", "properties"},
+		{"", ""},
+		{list, prop}
+	},
 }
 
 return formspec_elements

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -256,10 +256,7 @@ local formspec_elements = {
 
 formspec_elements.item_grid = function(values)
 	if values.interactable ~= false then
-		if type(values.name) ~= "string" then
-			values.name = "grid"
-		end
-		values.name = values.name.."_"
+		values.name = str(values.name, "grid").."_"
 	end
 	for v,d in pairs({X = 0, Y = 0, W = 1, H = 1, spacing = 0, size = 1, offset = 1}) do
 		if type(values[v]) ~= "number" then

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -107,7 +107,7 @@ local formspec_elements = {
 		{str, str, str, str},
 	},
 	tooltip_area = {
-		"tooltip[%s;%s;%s;%s]",
+		"tooltip[%s,%s;%s,%s;%s;%s;%s]",
 		{"X", "Y", "W", "H", "tooltip_text", "bgcolor", "fontcolor"},
 		{"0", "0", "100", "100", "tooltip area", "#303030", "#ffffff"},
 		{num, num, num, num, str, str, str},
@@ -155,7 +155,7 @@ local formspec_elements = {
 		{num, num, num, num, str, bool, middle}
 	},
 	pwdfield = {
-		"field[%s,%s;%s,%s;%s;%s]",
+		"pwdfield[%s,%s;%s,%s;%s;%s]",
 		{"X", "Y", "W", "H", "name", "label"},
 		{"0", "0", "3", "0.8", "pwdfield", ""},
 		{num, num, num, num, str, str}
@@ -187,7 +187,7 @@ local formspec_elements = {
 	hypertext = {
 		"hypertext[%s,%s;%s,%s;%s;%s]",
 		{"X", "Y", "W", "H", "name", "text"},
-		{"0", "0", "4", "3", "hypertext", "hypertext"},
+		{"0", "0", "4", "3", "hypertext", "<i>hypertext</i>"},
 		{num, num, num, num, str, str}
 	},
 	vertlabel = {
@@ -245,7 +245,7 @@ local formspec_elements = {
 		{num, num, num, num, str}
 	},
 	dropdown = {
-		"dropdown[%s,%s;%s,%s;%s;%s,%s;%s;%s]",
+		"dropdown[%s,%s;%s,%s;%s;%s;%s;%s]",
 		{"X", "Y", "W", "H", "name", "listelements", "selected_id", "index_event"},
 		{"0", "0", "3", "0.8", "dropdown", "a,b,c", "0", "false"},
 		{num, num, num, num, str, list, num, bool}
@@ -276,7 +276,7 @@ local table_options = {
 	border = bool,
 	highlight = str,
 	highlight_text = str,
-	open_depth = num
+	opendepth = num
 }
 
 local function column(value)

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -192,4 +192,25 @@ local formspec_elements = {
 	},
 }
 
+local function middle(value, default_value)
+	local t = type(value)
+	if t == "number" then
+		return string.format("%i", value)
+	elseif t ~= "string" then
+		return default_value
+	end
+	if value:match("^%-?%d+$") or value:match("^%-?%d+,%-?%d+$")
+			or value:match("^%-?%d+,%-?%d+,%-?%d+,%-?%d+$") then
+		return value
+	end
+	return default_value
+end
+
+formspec_elements.background9 = {
+	"background9[%s,%s;%s,%s;%s;%s;%s]",
+	{"X", "Y", "W", "H", "texture_name", "auto_clip", "middle"},
+	{"0", "0", "0", "0", "digistuff_ts_bg.png", "true", "3"},
+	{num, num, num, num, str, bool, middle}
+}
+
 return formspec_elements

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -115,7 +115,7 @@ local formspec_elements = {
 	image = {
 		"image[%s,%s;%s,%s;%s]",
 		{"X", "Y", "W", "H", "texture_name"},
-		{"0", "0", "1", "1", "default_dirt.png^default_grass_side.png"},
+		{"0", "0", "1", "1", "default_dirt.png"},
 		{num, num, num, num, str}
 	},
 	animated_image = {
@@ -269,7 +269,6 @@ local formspec_elements = {
 		{list, prop}
 	},
 }
-
 
 local table_options = {
 	color = str,

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -14,25 +14,19 @@ local function str(value, default_value)
 end
 
 local function list(value, default_value)
-	if type(value) ~= "table" then
-		if type(value) == "string" then
-			return minetest.formspec_escape(value)
-		end
-		return default_value
-	end
-	if #value < 1 then
+	if type(value) ~= "table" or #value < 1 then
 		return default_value
 	end
 	local new_list = {}
 	for _,v in ipairs(value) do
 		if type(v) == "string" then
-			new_list:insert(minetest.formspec_escape(v))
+			table.insert(new_list, minetest.formspec_escape(v))
 		end
 	end
 	if #new_list < 1 then
 		return default_value
 	end
-	return new_list:concat(",")
+	return table.concat(new_list, ",")
 end
 
 local function bool(value, default_value)

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -254,4 +254,43 @@ local formspec_elements = {
 	},
 }
 
+formspec_elements.item_grid = function(values)
+	if values.interactable ~= false then
+		if type(values.name) ~= "string" then
+			values.name = "grid"
+		end
+		values.name = values.name.."_"
+	end
+	for v,d in pairs({X = 0, Y = 0, W = 1, H = 1, spacing = 0, size = 1, offset = 1}) do
+		if type(values[v]) ~= "number" then
+			values[v] = d
+		end
+	end
+	local items = type(values.items) == "table" and values.items or {}
+	local offset = math.max(1, math.floor(values.offset)) - 1
+	local x, y, n, item = values.X, values.Y, 1
+	local grid = {}
+	for _=1, values.H do
+		for _=1, values.W do
+			item = items[n + offset]
+			if type(item) ~= "string" then
+				return table.concat(grid)
+			end
+			item = item:match("^[^ %[%]\\,;]* ?%d* ?%d*")
+			if values.interactable ~= false then
+				grid[n] = string.format("item_image_button[%s,%s;%s,%s;%s;%s;]",
+					x, y, values.size, values.size, item, values.name..n)
+			else
+				grid[n] = string.format("item_image[%s,%s;%s,%s;%s]",
+					x, y, values.size, values.size, item)
+			end
+			n = n + 1
+			x = x + values.size + values.spacing
+		end
+		x = values.X
+		y = y + values.size + values.spacing
+	end
+	return table.concat(grid)
+end
+
 return formspec_elements

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -80,6 +80,9 @@ local function process_command(meta, data, msg)
 		if msg.locked ~= nil then
 			meta:set_int("locked", msg.locked == false and 0 or 1)
 		end
+		if msg.no_prepend ~= nil then
+			meta:set_int("no_prepend", msg.no_prepend == false and 0 or 1)
+		end
 		if msg.real_coordinates ~= nil then
 			meta:set_int("real_coordinates", msg.real_coordinates == false and 0 or 1)
 		end
@@ -110,6 +113,9 @@ local function create_formspec(meta, data)
 		fs = fs.."size["..width..","..height..",true]"
 	else
 		fs = fs.."size["..width..","..height.."]"
+	end
+	if meta:get_int("no_prepend") == 1 then
+		fs = fs.."no_prepend[]"
 	end
 	if not meta:get("real_coordinates") and not meta:get("realcoordinates") then
 		fs = fs.."real_coordinates[false]"

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -218,6 +218,7 @@ minetest.register_node("digistuff:touchscreen", {
 	end,
 	on_receive_fields = on_receive_fields,
 	digilines = {
+		receptor = {},
 		effector = {
 			action = on_digiline
 		}

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -1,285 +1,194 @@
-digistuff.update_ts_formspec = function (pos)
-	local meta = minetest.get_meta(pos)
-	local fs = "size[10,8]"..
-		"background[0,0;0,0;digistuff_ts_bg.png;true]"
-	if meta:get_int("realcoordinates") > 0 then
-		fs = fs.."real_coordinates[true]"
+
+local unpack = table.unpack or unpack
+
+local formspec_elements = dofile(minetest.get_modpath("digistuff").."/formspec_elements.lua")
+
+local formspec_version = 4
+
+
+local function create_element_string(element, values)
+	if type(element) == "function" then
+		return element(values)
 	end
-	if meta:get_int("init") == 0 then
-		fs = fs.."field[3.75,3;3,1;channel;Channel;]"..
-		"button_exit[4,3.75;2,1;save;Save]"
-	elseif minetest.get_node(pos).name == "digistuff:advtouchscreen" then
-		fs = fs.."label[0,0;No data received yet]"
-	else
-		local data = minetest.deserialize(meta:get_string("data")) or {}
-		for _,field in pairs(data) do
-			if field.type == "image" then
-				fs = fs..string.format("image[%s,%s;%s,%s;%s]",field.X,field.Y,field.W,field.H,field.texture_name)
-			elseif field.type == "field" then
-				fs = fs..string.format("field[%s,%s;%s,%s;%s;%s;%s]",field.X,field.Y,field.W,field.H,field.name,field.label,field.default)
-			elseif field.type == "pwdfield" then
-				fs = fs..string.format("pwdfield[%s,%s;%s,%s;%s;%s]",field.X,field.Y,field.W,field.H,field.name,field.label)
-			elseif field.type == "textarea" then
-				fs = fs..string.format("textarea[%s,%s;%s,%s;%s;%s;%s]",field.X,field.Y,field.W,field.H,field.name,field.label,field.default)
-			elseif field.type == "label" then
-				fs = fs..string.format("label[%s,%s;%s]",field.X,field.Y,field.label)
-			elseif field.type == "vertlabel" then
-				fs = fs..string.format("vertlabel[%s,%s;%s]",field.X,field.Y,field.label)
-			elseif field.type == "button" then
-				fs = fs..string.format("button[%s,%s;%s,%s;%s;%s]",field.X,field.Y,field.W,field.H,field.name,field.label)
-			elseif field.type == "button_exit" then
-				fs = fs..string.format("button_exit[%s,%s;%s,%s;%s;%s]",field.X,field.Y,field.W,field.H,field.name,field.label)
-			elseif field.type == "image_button" then
-				fs = fs..string.format("image_button[%s,%s;%s,%s;%s;%s;%s]",field.X,field.Y,field.W,field.H,field.image,field.name,field.label)
-			elseif field.type == "image_button_exit" then
-				fs = fs..string.format("image_button_exit[%s,%s;%s,%s;%s;%s;%s]",field.X,field.Y,field.W,field.H,field.image,field.name,field.label)
-			elseif field.type == "dropdown" then
-				local choices = ""
-				for _,i in ipairs(field.choices) do
-					if type(i) == "string" then
-						choices = choices..minetest.formspec_escape(i)..","
-					end
-				end
-				choices = string.sub(choices,1,-2)
-				fs = fs..string.format("dropdown[%s,%s;%s,%s;%s;%s;%s]",field.X,field.Y,field.W,field.H,field.name,choices,field.selected_id)
-			elseif field.type == "textlist" then
-				local listelements = ""
-				for _,i in ipairs(field.listelements) do
-					if type(i) == "string" then
-						listelements = listelements..minetest.formspec_escape(i)..","
-					end
-				end
-				listelements = string.sub(listelements,1,-2)
-				fs = fs..string.format("textlist[%s,%s;%s,%s;%s;%s;%s;%s]",field.X,field.Y,field.W,field.H,field.name,listelements,field.selected_id,field.transparent)
-			end
-		end
+	local new_values = {}
+	for i,name in ipairs(element[2]) do
+		local value = element[4][i](values[name], element[3][i])
+		table.insert(new_values, value)
 	end
-	meta:set_string("formspec",fs)
+	return string.format(element[1], unpack(new_values))
 end
 
-digistuff.ts_on_receive_fields = function (pos, formname, fields, sender)
-	local meta = minetest.get_meta(pos)
-	local setchan = meta:get_string("channel")
-	local playername = sender:get_player_name()
-	local locked = meta:get_int("locked") == 1
-	local can_bypass = minetest.check_player_privs(playername,{protection_bypass=true})
-	local is_protected = minetest.is_protected(pos,playername)
-	if (locked and is_protected) and not can_bypass then
-		minetest.record_protection_violation(pos,playername)
-		minetest.chat_send_player(playername,"You are not authorized to use this screen.")
-		return
+local function check_old_command(msg)
+	local cmd = msg.command
+	if cmd == "lock" then
+		return {command = "set", locked = true}
 	end
-	local init = meta:get_int("init") == 1
-	if not init then
-		if fields.save then
-			meta:set_string("channel",fields.channel)
-			meta:set_int("init",1)
-			digistuff.update_ts_formspec(pos)
-		end
-	else
-		fields.clicker = sender:get_player_name()
-		digilines.receptor_send(pos, digilines.rules.default, setchan, fields)
+	if cmd == "unlock" then
+		return {command = "set", locked = false}
 	end
+	if cmd == "realcoordinates" then
+		return {command = "set", real_coordinates = true}
+	end
+	if string.match(cmd, "^add%a+") then
+		msg.element = string.sub(cmd, 4)
+		msg.command = "add"
+	end
+	return msg
 end
 
-digistuff.process_command = function (meta, data, msg)
-	if msg.command == "clear" then
+local function process_command(meta, data, msg)
+	msg = check_old_command(msg)
+	local cmd = msg.command
+
+	if cmd == "clear" then
 		data = {}
-	elseif msg.command == "realcoordinates" then
-		meta:set_int("realcoordinates",msg.enabled and 1 or 0)
-	elseif msg.command == "addimage" then
-		for _,i in pairs({"X","Y","W","H"}) do
-			if not msg[i] or type(msg[i]) ~= "number" then
-				return
+
+	elseif cmd == "add" then
+		local element = formspec_elements[msg.element]
+		if element then
+			local str = create_element_string(element, msg)
+			table.insert(data, str)
+		end
+
+	elseif cmd == "insert" then
+		local element = formspec_elements[msg.element]
+		local index = tonumber(msg.index)
+		if element and index and index > 0 then
+			local str = create_element_string(element, msg)
+			if index > #data then
+				table.insert(data, str)
+			else
+				table.insert(data, index, str)
 			end
 		end
-		if not msg.texture_name or type(msg.texture_name) ~= "string" then
-			return
+
+	elseif cmd == "replace" then
+		local element = formspec_elements[msg.element]
+		local index = tonumber(msg.index)
+		if element and index and data[index] then
+			local str = create_element_string(element, msg)
+			data[index] = str
 		end
-		local field = {type="image",X=msg.X,Y=msg.Y,W=msg.W,H=msg.H,texture_name=minetest.formspec_escape(msg.texture_name)}
-		table.insert(data,field)
-	elseif msg.command == "addfield" then
-		for _,i in pairs({"X","Y","W","H"}) do
-			if not msg[i] or type(msg[i]) ~= "number" then
-				return
-			end
+
+	elseif cmd == "remove" then
+		local index = tonumber(msg.index)
+		if index and data[index] then
+			table.remove(data, index)
 		end
-		for _,i in pairs({"name","label","default"}) do
-			if not msg[i] or type(msg[i]) ~= "string" then
-				return
-			end
+
+	elseif cmd == "set" then
+		if msg.locked ~= nil then
+			meta:set_int("locked", msg.locked == false and 0 or 1)
 		end
-		local field = {type="field",X=msg.X,Y=msg.Y,W=msg.W,H=msg.H,name=minetest.formspec_escape(msg.name),label=minetest.formspec_escape(msg.label),default=minetest.formspec_escape(msg.default)}
-		table.insert(data,field)
-	elseif msg.command == "addpwdfield" then
-		for _,i in pairs({"X","Y","W","H"}) do
-			if not msg[i] or type(msg[i]) ~= "number" then
-				return
-			end
+		if msg.real_coordinates ~= nil then
+			meta:set_int("real_coordinates", msg.real_coordinates == false and 0 or 1)
 		end
-		for _,i in pairs({"name","label"}) do
-			if not msg[i] or type(msg[i]) ~= "string" then
-				return
-			end
+		if msg.fixed_size ~= nil then
+			meta:set_int("fixed_size", msg.fixed_size == false and 0 or 1)
 		end
-		local field = {type="pwdfield",X=msg.X,Y=msg.Y,W=msg.W,H=msg.H,name=minetest.formspec_escape(msg.name),label=minetest.formspec_escape(msg.label)}
-		table.insert(data,field)
-	elseif msg.command == "addtextarea" then
-		for _,i in pairs({"X","Y","W","H"}) do
-			if not msg[i] or type(msg[i]) ~= "number" then
-				return
-			end
+		if type(msg.width) == "number" then
+			local value = math.max(1, math.min(100, msg.width))
+			meta:set_string("width", string.format("%.4g", value))
 		end
-		for _,i in pairs({"name","label","default"}) do
-			if not msg[i] or type(msg[i]) ~= "string" then
-				return
-			end
+		if type(msg.height) == "number" then
+			local value = math.max(1, math.min(100, msg.height))
+			meta:set_string("height", string.format("%.4g", value))
 		end
-		local field = {type="textarea",X=msg.X,Y=msg.Y,W=msg.W,H=msg.H,name=minetest.formspec_escape(msg.name),label=minetest.formspec_escape(msg.label),default=minetest.formspec_escape(msg.default)}
-		table.insert(data,field)
-	elseif msg.command == "addlabel" then
-		for _,i in pairs({"X","Y"}) do
-			if not msg[i] or type(msg[i]) ~= "number" then
-				return
-			end
+		if type(msg.focus) == "string" then
+			meta:set_string("focus", minetest.formspec_escape(msg.focus))
 		end
-		if not msg.label or type(msg.label) ~= "string" then
-			return
-		end
-		local field = {type="label",X=msg.X,Y=msg.Y,label=minetest.formspec_escape(msg.label)}
-		table.insert(data,field)
-	elseif msg.command == "addvertlabel" then
-		for _,i in pairs({"X","Y"}) do
-			if not msg[i] or type(msg[i]) ~= "number" then
-				return
-			end
-		end
-		if not msg.label or type(msg.label) ~= "string" then
-			return
-		end
-		local field = {type="vertlabel",X=msg.X,Y=msg.Y,label=minetest.formspec_escape(msg.label)}
-		table.insert(data,field)
-	elseif msg.command == "addbutton" then
-		for _,i in pairs({"X","Y","W","H"}) do
-			if not msg[i] or type(msg[i]) ~= "number" then
-				return
-			end
-		end
-		for _,i in pairs({"name","label"}) do
-			if not msg[i] or type(msg[i]) ~= "string" then
-				return
-			end
-		end
-		local field = {type="button",X=msg.X,Y=msg.Y,W=msg.W,H=msg.H,name=minetest.formspec_escape(msg.name),label=minetest.formspec_escape(msg.label)}
-		table.insert(data,field)
-	elseif msg.command == "addbutton_exit" then
-		for _,i in pairs({"X","Y","W","H"}) do
-			if not msg[i] or type(msg[i]) ~= "number" then
-				return
-			end
-		end
-		for _,i in pairs({"name","label"}) do
-			if not msg[i] or type(msg[i]) ~= "string" then
-				return
-			end
-		end
-		local field = {type="button_exit",X=msg.X,Y=msg.Y,W=msg.W,H=msg.H,name=minetest.formspec_escape(msg.name),label=minetest.formspec_escape(msg.label)}
-		table.insert(data,field)
-	elseif msg.command == "addimage_button" then
-		for _,i in pairs({"X","Y","W","H"}) do
-			if not msg[i] or type(msg[i]) ~= "number" then
-				return
-			end
-		end
-		for _,i in pairs({"image","name","label"}) do
-			if not msg[i] or type(msg[i]) ~= "string" then
-				return
-			end
-		end
-		local field = {type="image_button",X=msg.X,Y=msg.Y,W=msg.W,H=msg.H,image=minetest.formspec_escape(msg.image),name=minetest.formspec_escape(msg.name),label=minetest.formspec_escape(msg.label)}
-		table.insert(data,field)
-	elseif msg.command == "addimage_button_exit" then
-		for _,i in pairs({"X","Y","W","H"}) do
-			if not msg[i] or type(msg[i]) ~= "number" then
-				return
-			end
-		end
-		for _,i in pairs({"image","name","label"}) do
-			if not msg[i] or type(msg[i]) ~= "string" then
-				return
-			end
-		end
-		local field = {type="image_button_exit",X=msg.X,Y=msg.Y,W=msg.W,H=msg.H,image=minetest.formspec_escape(msg.image),name=minetest.formspec_escape(msg.name),label=minetest.formspec_escape(msg.label)}
-		table.insert(data,field)
-	elseif msg.command == "adddropdown" then
-		for _,i in pairs({"X","Y","W","H","selected_id"}) do
-			if not msg[i] or type(msg[i]) ~= "number" then
-				return
-			end
-		end
-		if not msg.name or type(msg.name) ~= "string" then
-			return
-		end
-		if not msg.choices or type(msg.choices) ~= "table" or #msg.choices < 1 then
-			return
-		end
-		local field = {type="dropdown",X=msg.X,Y=msg.Y,W=msg.W,H=msg.H,name=minetest.formspec_escape(msg.name),selected_id=msg.selected_id,choices=msg.choices}
-		table.insert(data,field)
-	elseif msg.command == "addtextlist" then
-		for _,i in pairs({"X","Y","W","H","selected_id"}) do
-			if not msg[i] or type(msg[i]) ~= "number" then
-				return
-			end
-		end
-		if not msg.name or type(msg.name) ~= "string" then
-			return
-		end
-		if not msg.listelements or type(msg.listelements) ~= "table" or #msg.listelements < 1 then
-			return
-		end
-		if not msg.transparent or type(msg.transparent) ~= "boolean" then
-			msg.transparent = false
-		end
-		local field = {type="textlist",X=msg.X,Y=msg.Y,W=msg.W,H=msg.H,name=minetest.formspec_escape(msg.name),selected_id=msg.selected_id,listelements=msg.listelements,transparent=msg.transparent}
-		table.insert(data,field)
-	elseif msg.command == "lock" then
-		meta:set_int("locked",1)
-	elseif msg.command == "unlock" then
-		meta:set_int("locked",0)
 	end
+
 	return data
 end
 
-digistuff.ts_on_digiline_receive = function (pos, node, channel, msg)
-	local meta = minetest.get_meta(pos)
-	local setchan = meta:get_string("channel")
-	if channel ~= setchan then return end
-	if node.name == "digistuff:advtouchscreen" then
-		if type(msg) == "string" then meta:set_string("formspec",msg) end
+local function create_formspec(meta, data)
+	local fs = "formspec_version["..formspec_version.."]"
+	local width = tonumber(meta:get_string("width")) or 10
+	local height = tonumber(meta:get_string("height")) or 8
+	if meta:get_int("fixed_size") == 1 then
+		fs = fs.."size["..width..","..height..",true]"
 	else
-		if type(msg) ~= "table" then return end
-		local data = minetest.deserialize(meta:get_string("data")) or {}
-		if msg.command then
-			data = digistuff.process_command(meta,data,msg)
-		else
-			for _,i in ipairs(msg) do
-				if type(i) == "table" and i.command then
-					data = digistuff.process_command(meta,data,i) or data
-				end
-			end
-		end
-		meta:set_string("data",minetest.serialize(data))
-		digistuff.update_ts_formspec(pos)
+		fs = fs.."size["..width..","..height.."]"
+	end
+	if not meta:get("real_coordinates") and not meta:get("realcoordinates") then
+		fs = fs.."real_coordinates[false]"
+	end
+	local focus = meta:get("focus")
+	if focus then
+		fs = fs.."set_focus["..focus.."]"
+	end
+	return fs..table.concat(data)
+end
+
+local function update_formspec(pos, meta, data)
+	data = data or minetest.deserialize(meta:get("data"))
+	if not meta:get("init") then
+		meta:set_string("formspec", "field[channel;Channel;]")
+	elseif not data then
+		meta:set_string("formspec", "size[10,8]")
+	else
+		meta:set_string("formspec", create_formspec(meta, data))
 	end
 end
 
+local function convert_old_data(data)
+	local new_data = {}
+	for _,v in pairs(data) do
+		local element = formspec_elements[v.type]
+		local s = create_element_string(element, v)
+		table.insert(new_data, s)
+	end
+	return new_data
+end
+
+local function on_digiline(pos, node, channel, msg)
+	if type(msg) ~= "table" then
+		return
+	end
+	local meta = minetest.get_meta(pos)
+	if channel ~= meta:get_string("channel") then
+		return
+	end
+	local data = minetest.deserialize(meta:get_string("data")) or {}
+	if next(data) == "table" then
+		data = convert_old_data(data)
+	end
+	if msg.command then
+		data = process_command(meta, data, msg)
+	else
+		for _,v in ipairs(msg) do
+			if type(v) == "table" and v.command then
+				data = process_command(meta, data, v)
+			end
+		end
+	end
+	meta:set_string("data", minetest.serialize(data))
+	update_formspec(pos, meta, data)
+end
+
+local function on_receive_fields(pos, _, fields, player)
+	local meta = minetest.get_meta(pos)
+	local name = player:get_player_name()
+	if meta:get_int("locked") == 1 and minetest.is_protected(pos, name) then
+		minetest.chat_send_player(name, "You are not authorized to use this screen.")
+		return
+	end
+	if not meta:get("init") and fields.channel then
+		meta:set_string("channel", fields.channel)
+		meta:set_int("init", 1)
+		update_formspec(pos, meta)
+	else
+		local channel = meta:get_string("channel")
+		fields.clicker = name
+		digilines.receptor_send(pos, digilines.rules.default, channel, fields)
+	end
+end
+
+
 minetest.register_node("digistuff:touchscreen", {
 	description = "Digilines Touchscreen",
-	groups = {cracky=3},
-	on_construct = function(pos)
-		digistuff.update_ts_formspec(pos,true)
-	end,
-	drawtype = "nodebox",
+	groups = {cracky = 3},
 	tiles = {
 		"digistuff_panel_back.png",
 		"digistuff_panel_back.png",
@@ -287,71 +196,30 @@ minetest.register_node("digistuff:touchscreen", {
 		"digistuff_panel_back.png",
 		"digistuff_panel_back.png",
 		"digistuff_ts_front.png"
-		},
-	paramtype = "light",
-	paramtype2 = "facedir",
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{ -0.5, -0.5, 0.4, 0.5, 0.5, 0.5 }
-		}
 	},
-	_digistuff_channelcopier_fieldname = "channel",
-	_digistuff_channelcopier_onset = function(pos)
-		minetest.get_meta(pos):set_int("init",1)
-		digistuff.update_ts_formspec(pos)
-	end,
-	on_receive_fields = digistuff.ts_on_receive_fields,
-	digiline = {
-		receptor = {},
-		effector = {
-			action = digistuff.ts_on_digiline_receive
-		},
-	},
-})
-
-minetest.register_node("digistuff:advtouchscreen", {
-	description = "Advanced Digilines Touchscreen",
-	groups = {cracky=3},
-	on_construct = function(pos)
-		digistuff.update_ts_formspec(pos,true)
-	end,
 	drawtype = "nodebox",
-	tiles = {
-		"digistuff_panel_back.png",
-		"digistuff_panel_back.png",
-		"digistuff_panel_back.png",
-		"digistuff_panel_back.png",
-		"digistuff_panel_back.png",
-		"digistuff_advts_front.png"
-		},
 	paramtype = "light",
 	paramtype2 = "facedir",
 	node_box = {
 		type = "fixed",
 		fixed = {
-			{ -0.5, -0.5, 0.4, 0.5, 0.5, 0.5 }
+			{-0.5, -0.5, 0.4, 0.5, 0.5, 0.5}
+		}
+	},
+	on_construct = function(pos)
+		local meta = minetest.get_meta(pos)
+		update_formspec(pos, meta)
+	end,
+	on_receive_fields = on_receive_fields,
+	digilines = {
+		effector = {
+			action = on_digiline
 		}
 	},
 	_digistuff_channelcopier_fieldname = "channel",
 	_digistuff_channelcopier_onset = function(pos)
-		minetest.get_meta(pos):set_int("init",1)
-		digistuff.update_ts_formspec(pos)
+		local meta = minetest.get_meta(pos)
+		meta:set_int("init", 1)
+		update_formspec(pos, meta)
 	end,
-	on_receive_fields = digistuff.ts_on_receive_fields,
-	digiline = {
-		receptor = {},
-		effector = {
-			action = digistuff.ts_on_digiline_receive
-		},
-	},
-})
-
-minetest.register_craft({
-	output = "digistuff:touchscreen",
-	recipe = {
-		{"mesecons_luacontroller:luacontroller0000","default:glass","default:glass"},
-		{"default:glass","digilines:lcd","default:glass"},
-		{"default:glass","default:glass","default:glass"}
-	}
 })

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -5,7 +5,6 @@ local formspec_elements = dofile(minetest.get_modpath("digistuff").."/formspec_e
 
 local formspec_version = 4
 
-
 local function create_element_string(element, values)
 	if type(element) == "function" then
 		return element(values)
@@ -191,7 +190,6 @@ local function on_receive_fields(pos, _, fields, player)
 	end
 end
 
-
 minetest.register_node("digistuff:touchscreen", {
 	description = "Digilines Touchscreen",
 	groups = {cracky = 3},
@@ -230,3 +228,14 @@ minetest.register_node("digistuff:touchscreen", {
 		update_formspec(pos, meta)
 	end,
 })
+
+minetest.register_craft({
+	output = "digistuff:touchscreen",
+	recipe = {
+		{"mesecons_luacontroller:luacontroller0000", "default:glass", "default:glass"},
+		{"default:glass", "digilines:lcd", "default:glass"},
+		{"default:glass", "default:glass", "default:glass"}
+	}
+})
+
+minetest.register_alias("digistuff:advtouchscreen", "digistuff:touchscreen")

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -26,7 +26,7 @@ local function check_old_command(msg)
 		return {command = "set", locked = false}
 	end
 	if cmd == "realcoordinates" then
-		return {command = "set", real_coordinates = true}
+		return {command = "set", real_coordinates = msg.enabled}
 	end
 	if string.match(cmd, "^add%a+") then
 		msg.element = string.sub(cmd, 4)
@@ -158,11 +158,11 @@ local function on_digiline(pos, node, channel, msg)
 		return
 	end
 	local data = get_data(meta) or {}
-	if msg.command then
+	if type(msg.command) == "string" then
 		data = process_command(meta, data, msg)
 	else
 		for _,v in ipairs(msg) do
-			if type(v) == "table" and v.command then
+			if type(v) == "table" and type(v.command) == "string" then
 				data = process_command(meta, data, v)
 			end
 		end


### PR DESCRIPTION
A big rewrite of the `digistuff:touchscreen`, long overdue...

### Goals

- Support for as many formspec elements as possible.
- Easy to maintain code. (for adding future formspec elements)
- Simple digiline commands. (with default values automatically filled in)

### TODO

- [x] Add alias for `digistuff:advtouchscreen`.
- [x] Add documentation.
- [x] Make sure old touchscreens update correctly.
- [x] Make sure all old commands work the same.
- [x] Test all formspec elements

### Unupported formspec elements

- `position`
- `anchor`
- `container`, `container_end`
- `scroll_container`, `scroll_container_end`
- `scrollbar`, `scrollbaroptions`
- `list`, `listring`, `listcolors`

Closes #21, Fixes #20