### PR TITLE
fix warning when `qos` is not enabled

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -33,6 +33,6 @@ if not http then
 	minetest.log("warning","digistuff is not allowed to use the HTTP API - digilines NIC will not be available!")
 	minetest.log("warning","If this functionality is desired, please add digistuff to your secure.http_mods setting")
 else
-	local qos_http = QoS and QoS(http, 3) or http
+	local qos_http = minetest.get_modpath("qos") and QoS(http, 3) or http
 	loadfile(string.format("%s%s%s.lua",minetest.get_modpath(minetest.get_current_modname()),DIR_DELIM,"nic"))(qos_http)
 end


### PR DESCRIPTION
```
2022-01-10 01:05:23: WARNING[Main]: Undeclared global variable "QoS" accessed at ...minetest/minetest.git/bin/../mods/digistuff/init.lua:36
```