### PR TITLE
Use standard key names instead of configurable

### DIFF
--- a/channelcopier.lua
+++ b/channelcopier.lua
@@ -1,5 +1,5 @@
 minetest.register_tool("digistuff:channelcopier",{
-	description = "Digilines Channel Copier (shift-click to copy, click to paste)",
+	description = "Digilines Channel Copier (sneak-click to copy, click to paste)",
 	inventory_image = "digistuff_channelcopier.png",
 	on_use = function(itemstack,player,pointed)
 		if not (pointed and pointed.under) then return itemstack end
@@ -25,7 +25,7 @@ minetest.register_tool("digistuff:channelcopier",{
 				if minetest.registered_nodes[node.name]._digistuff_channelcopier_fieldname then
 					local channel = itemstack:get_meta():get_string("channel")
 					if type(channel) ~= "string" or channel == "" then
-						minetest.chat_send_player(name,minetest.colorize("#FF5555","Error:").." No channel has been set yet. Shift-click to copy one.")
+						minetest.chat_send_player(name,minetest.colorize("#FF5555","Error:").." No channel has been set yet. Sneak-click to copy one.")
 						return itemstack
 					end
 					local oldchannel = minetest.get_meta(pos):get_string(minetest.registered_nodes[node.name]._digistuff_channelcopier_fieldname)


### PR DESCRIPTION
Can we please use the names from api or key-binding dialog.