### PR TITLE
Touchscreen updates

### DIFF
--- a/docs/touchscreen.md
+++ b/docs/touchscreen.md
@@ -54,6 +54,15 @@ digiline_send("touchscreen", {
 })
 ```
 
+**`modify`** - Replaces specified values of an existing element.
+
+```lua
+digiline_send("touchscreen", {
+	command = "modify",
+	index = 1,
+})
+```
+
 **`remove`** - Removes an element.
 
 ```lua
@@ -86,6 +95,8 @@ digiline_send("touchscreen", {
 ```
 
 ## Supported formspec elements
+
+The touchscreen uses formspec version 6 (Minetest 5.6.0+).
 
 **Standard elements:**
 
@@ -137,6 +148,7 @@ These elements, for design or other reasons, are not supported by the touchscree
 - `formspec_version`
 - `position`
 - `anchor`
+- `padding`
 - `container`
 - `container_end`
 - `scroll_container`
@@ -193,6 +205,7 @@ digiline_send("touchscreen", {
 	W = 1,
 	H = 1,
 	texture_name = "default_dirt.png",
+	middle = "",
 })
 ```
 
@@ -211,6 +224,7 @@ digiline_send("touchscreen", {
 	frame_count = 16,
 	frame_duration = 200,
 	frame_start = 1,
+	middle = "",
 })
 ```
 

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -17,7 +17,7 @@ local function num(value, default_value)
 	if type(value) ~= "number" then
 		return default_value
 	end
-	return string.format("%.4g", value)
+	return string.format("%s", math.floor(value * 1000) / 1000)
 end
 
 local function str(value, default_value)
@@ -89,9 +89,9 @@ local function prop(value, default_value)  -- Only for `stlye` and `style_type`
 			if type(v) == "string" then
 				table.insert(new_prop, k..fs_escape(v, true))
 			elseif type(v) == "number" then
-				table.insert(new_prop, k..string.format("%.4g", v))
+				table.insert(new_prop, k..num(v))
 			elseif type(v) == "boolean" then
-				table.insert(new_prop, k..(v and "true" or "false"))
+				table.insert(new_prop, k..bool(v))
 			end
 		end
 	end

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -270,6 +270,15 @@ local formspec_elements = {
 	},
 }
 
+-- Create un-format strings for modifying elements
+for _,element in pairs(formspec_elements) do
+	local s = string.gsub(element[1], "%%s", "(.*)")
+	s = string.gsub(s, "%[", "%%[")
+	s = string.gsub(s, "%]", "%%]")
+	element[5] = "^"..s.."$"
+end
+
+
 local table_options = {
 	color = str,
 	background = str,

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -14,6 +14,9 @@ local function fs_escape(text, is_list)
 end
 
 local function num(value, default_value)
+	if type(value) == "string" then
+		value = tonumber(value)
+	end
 	if type(value) ~= "number" then
 		return default_value
 	end
@@ -28,6 +31,9 @@ local function str(value, default_value)
 end
 
 local function bool(value, default_value)
+	if value == "true" or value == "false" then
+		return value
+	end
 	if type(value) ~= "boolean" then
 		return default_value
 	end

--- a/formspec_elements.lua
+++ b/formspec_elements.lua
@@ -113,16 +113,16 @@ local formspec_elements = {
 		{num, num, num, num, str, str, str},
 	},
 	image = {
-		"image[%s,%s;%s,%s;%s]",
-		{"X", "Y", "W", "H", "texture_name"},
-		{"0", "0", "1", "1", "default_dirt.png"},
-		{num, num, num, num, str}
+		"image[%s,%s;%s,%s;%s;%s]",
+		{"X", "Y", "W", "H", "texture_name", "middle"},
+		{"0", "0", "1", "1", "default_dirt.png", ""},
+		{num, num, num, num, str, middle}
 	},
 	animated_image = {
-		"animated_image[%s,%s;%s,%s;%s;%s;%s;%s;%s]",
-		{"X", "Y", "W", "H", "name", "texture_name", "frame_count", "frame_duration", "frame_start"},
-		{"0", "0", "1", "1", "animated_image", "default_lava_flowing_animated.png", "16", "200", "1"},
-		{num, num, num, num, str, str, num, num, num}
+		"animated_image[%s,%s;%s,%s;%s;%s;%s;%s;%s;%s]",
+		{"X", "Y", "W", "H", "name", "texture_name", "frame_count", "frame_duration", "frame_start", "middle"},
+		{"0", "0", "1", "1", "animated_image", "default_lava_flowing_animated.png", "16", "200", "1", ""},
+		{num, num, num, num, str, str, num, num, num, middle}
 	},
 	model = {
 		"model[%s,%s;%s,%s;%s;%s;%s;%s,%s;%s;%s;0,0]",

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -18,7 +18,6 @@ local function create_element_string(element, values)
 end
 
 local function modify_element_string(old, values)
-	local t = minetest.get_us_time()
 	local e = string.match(old, "^(.+)%[")
 	local element = formspec_elements[e]
 	if type(element) == "function" then
@@ -30,7 +29,6 @@ local function modify_element_string(old, values)
 		local value = element[4][i](values[name], old_values[i] or element[3][i])
 		table.insert(new_values, value)
 	end
-	print("time = "..(minetest.get_us_time() - t))
 	return string.format(element[1], unpack(new_values))
 end
 

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -17,6 +17,23 @@ local function create_element_string(element, values)
 	return string.format(element[1], unpack(new_values))
 end
 
+local function modify_element_string(old, values)
+	local t = minetest.get_us_time()
+	local e = string.match(old, "^(.+)%[")
+	local element = formspec_elements[e]
+	if type(element) == "function" then
+		return old  -- No-op for special elements, as there is no format string
+	end
+	local old_values = {string.match(old, element[5])}
+	local new_values = {}
+	for i,name in ipairs(element[2]) do
+		local value = element[4][i](values[name], old_values[i] or element[3][i])
+		table.insert(new_values, value)
+	end
+	print("time = "..(minetest.get_us_time() - t))
+	return string.format(element[1], unpack(new_values))
+end
+
 local function check_old_command(msg)
 	local cmd = msg.command
 	if cmd == "lock" then
@@ -70,6 +87,13 @@ local function process_command(meta, data, msg)
 		local index = tonumber(msg.index)
 		if element and index and data[index] then
 			local str = create_element_string(element, msg)
+			data[index] = str
+		end
+
+	elseif cmd == "modify" then
+		local index = tonumber(msg.index)
+		if index and data[index] then
+			local str = modify_element_string(data[index], msg)
 			data[index] = str
 		end
 

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -3,7 +3,7 @@ local unpack = table.unpack or unpack
 
 local formspec_elements = dofile(minetest.get_modpath("digistuff").."/formspec_elements.lua")
 
-local formspec_version = 4
+local formspec_version = 6
 
 local function create_element_string(element, values)
 	if type(element) == "function" then


### PR DESCRIPTION
A few updates for the touchscreen:
- Fix number formatting loosing precision with large values.
- Update for formspec version 6
- Add `modify` command.
- Allow string values to be used for number and boolean values.

Would be good to test the `modify` command a bit before merging, it *should* work for all elements, but I've been wrong before...

@SwissalpS @FeXoR-o-Illuria