### PR TITLE
Touchscreen "insert" command rework

### DIFF
--- a/docs/touchscreen.md
+++ b/docs/touchscreen.md
@@ -63,11 +63,20 @@ digiline_send("touchscreen", {
 })
 ```
 
-**`remove`** - Removes an element.
+**`remove`** - Removes an element and resizes the formspec array to fill the gaps.
 
 ```lua
 digiline_send("touchscreen", {
 	command = "remove",
+	index = 1,
+})
+```
+
+**`delete`** - Removes an element but it **doesn't** resizes the fromspec array.
+
+```lua
+digiline_send("touchscreen", {
+	command = "delete",
 	index = 1,
 })
 ```

--- a/docs/touchscreen.md
+++ b/docs/touchscreen.md
@@ -34,7 +34,7 @@ digiline_send("touchscreen", {
 })
 ```
 
-**`insert`** - Adds an element at a specific index.
+**`insert`** - Adds an element at a specific index. The index can be any positive number.
 
 ```lua
 digiline_send("touchscreen", {
@@ -63,7 +63,7 @@ digiline_send("touchscreen", {
 })
 ```
 
-**`remove`** - Removes an element and **reorders** indexes of elements.
+**`remove`** - Removes an element, shifting elements to fill the space.
 
 ```lua
 digiline_send("touchscreen", {
@@ -72,7 +72,7 @@ digiline_send("touchscreen", {
 })
 ```
 
-**`delete`** - Removes an element but **keeps** the indexes of elements.
+**`delete`** - Removes an element without changing element indexes.
 
 ```lua
 digiline_send("touchscreen", {
@@ -81,7 +81,7 @@ digiline_send("touchscreen", {
 })
 ```
 
-**`clear`** - Removes all elements, but keeps settings.
+**`clear`** - Removes all elements.
 
 ```lua
 digiline_send("touchscreen", {

--- a/docs/touchscreen.md
+++ b/docs/touchscreen.md
@@ -63,7 +63,7 @@ digiline_send("touchscreen", {
 })
 ```
 
-**`remove`** - Removes an element and resizes the formspec array to fill the gaps.
+**`remove`** - Removes an element and **reorders** indexes of elements.
 
 ```lua
 digiline_send("touchscreen", {
@@ -72,7 +72,7 @@ digiline_send("touchscreen", {
 })
 ```
 
-**`delete`** - Removes an element but it **doesn't** resizes the fromspec array.
+**`delete`** - Removes an element but **keeps** the indexes of elements.
 
 ```lua
 digiline_send("touchscreen", {

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -93,7 +93,7 @@ local function process_command(meta, data, msg)
 
 	elseif cmd == "remove" then
 		local index = tonumber(msg.index)
-		if index and data[index] then
+		if index and data[index] ~= nil then
 			table.remove(data, index)
 		end
 

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -93,14 +93,14 @@ local function process_command(meta, data, msg)
 
 	elseif cmd == "remove" then
 		local index = tonumber(msg.index)
-		if index and data[index] ~= nil then
+		if index and data[index] then
 			table.remove(data, index)
 		end
 
 	elseif cmd == "remove_without_resize" then
 		local index = tonumber(msg.index)
 		if index and data[index] then
-			data[index] = nil
+			data[index] = ""
 		end
 
 	elseif cmd == "set" then
@@ -164,13 +164,7 @@ local function create_formspec(meta, data)
 		fs = fs.."set_focus["..focus.."]"
 	end
 
-	local formspec_result = fs
-	for idx = 1, #data, 1 do -- ipairs not used because ipairs halts when it sees a gap (nil).
-		if data[idx] ~= nil then
-			formspec_result = formspec_result .. data[idx]
-		end 
-	end
-	return formspec_result
+	return fs..table.concat(data)
 end
 
 local function update_formspec(pos, meta, data)

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -164,7 +164,21 @@ local function create_formspec(meta, data)
 		fs = fs.."set_focus["..focus.."]"
 	end
 
-	return fs..table.concat(data)
+	local data_size = 0
+	for idx, val in pairs(data) do
+		if idx > data_size then
+			data_size = idx
+		end
+	end
+	
+	local formspec_result = fs
+	for i = 1, data_size, 1 do
+		if data[i] then
+			formspec_result = formspec_result..data[i]
+		end
+	end
+	
+	return formspec_result
 end
 
 local function update_formspec(pos, meta, data)

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -97,6 +97,12 @@ local function process_command(meta, data, msg)
 			table.remove(data, index)
 		end
 
+	elseif cmd == "remove_without_resize" then
+		local index = tonumber(msg.index)
+		if index and data[index] then
+			data[index] = nil
+		end
+
 	elseif cmd == "set" then
 		if msg.locked ~= nil then
 			meta:set_int("locked", msg.locked == false and 0 or 1)
@@ -157,7 +163,14 @@ local function create_formspec(meta, data)
 	if focus then
 		fs = fs.."set_focus["..focus.."]"
 	end
-	return fs..table.concat(data)
+
+	local formspec_result = fs
+	for idx = 1, #data, 1 do -- ipairs not used because ipairs halts when it sees a gap (nil).
+		if data[idx] ~= nil then
+			formspec_result = formspec_result .. data[idx]
+		end 
+	end
+	return formspec_result
 end
 
 local function update_formspec(pos, meta, data)

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -73,11 +73,7 @@ local function process_command(meta, data, msg)
 		local index = tonumber(msg.index)
 		if element and index and index > 0 then
 			local str = create_element_string(element, msg)
-			if index > #data then
-				table.insert(data, str)
-			else
-				table.insert(data, index, str)
-			end
+			table.insert(data, index, str)
 		end
 
 	elseif cmd == "replace" then


### PR DESCRIPTION
As described on the [documentation](https://github.com/mt-mods/digistuff/blob/master/docs/touchscreen.md), `insert` command adds an element at specified index. However, when checking out the code, this command _only_ works as described if the _index_ value is less than or equal to the size of the formspec array.

This makes it impossible to insert elements at indexes beyond the size of array, as that's what I need to make static formspec elements without repeatedly sending the same static element data.

This pull request changes the behavior of `insert` command: Don't do any size checks, let `table.insert` resize the array and add the element. And this request also adds a new command called `remove_without_resize`. This command just sets the specified index of the array to a empty string but it doesn't resizes the array. This function is added seprately for maintaining backwards compatibility. 

Please let me know if there is any issues involving this request, have nice day.