### PR TITLE
Implement maximum response length

### DIFF
--- a/nic.lua
+++ b/nic.lua
@@ -68,9 +68,14 @@ minetest.register_node("digistuff:nic", {
 							user_agent = "Minetest Digilines Modem"
 						},
 						function(res)
-							if type(res.data) == "string" and parse_json then
-								-- parse json data and replace payload
-								res.data = minetest.parse_json(res.data)
+							if type(res.data) == "string" then
+								if parse_json then
+									-- parse json data and replace payload
+									res.data = minetest.parse_json(res.data)
+								else
+									local max_length = minetest.settings:get("digistuff_max_nic_length") or 5000
+									res.data = res.data:sub(-max_length)
+								end
 							end
 							digilines.receptor_send(pos, digilines.rules.default, channel, res)
 						end)

--- a/settingstypes.txt
+++ b/settingstypes.txt
@@ -1,0 +1,3 @@
+[digistuff]
+
+digistuff_max_nic_length (Maximum NIC response length) int 5000 2000 10000


### PR DESCRIPTION
This pull request limits the response length of the NIC (to prevent the "message too complex" error). By default, the maximum length is 5,000 characters. This does not affect JSON data.