### PR TITLE
Add camera and detector visualizations

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -9,8 +9,7 @@ globals = {
 
 read_globals = {
 	-- Builtin
-	table = {fields = {"copy"}},
-
+	"table.copy",
 	"vector",
 	"ItemStack",
 	"DIR_DELIM",
@@ -19,7 +18,8 @@ read_globals = {
 	"default",
 	"mesecon",
 	"screwdriver",
-	"QoS"
+	"QoS",
+	"vizlib",
 }
 
 exclude_files = {

--- a/detector.lua
+++ b/detector.lua
@@ -28,6 +28,15 @@ local function search_for_players(pos, send_empty)
 	return true
 end
 
+local function show_area(pos, node, player)
+	if not player or player:get_wielded_item():get_name() ~= "" then
+		-- Only show area when using an empty hand
+		return
+	end
+	local radius = minetest.get_meta(pos):get_int("radius")
+	vizlib.draw_sphere(pos, radius, {player = player})
+end
+
 minetest.register_node("digistuff:detector", {
 	description = "Digilines Player Detector",
 	tiles = {
@@ -63,6 +72,7 @@ minetest.register_node("digistuff:detector", {
 		end
 	end,
 	on_timer = search_for_players,
+	on_punch = minetest.get_modpath("vizlib") and show_area or nil,
 	digiline = {
 		receptor = {},
 		effector = {

--- a/mod.conf
+++ b/mod.conf
@@ -2,4 +2,4 @@ name = digistuff
 title = digistuff
 description = Random digilines devices for Minetest
 depends = digilines
-optional_depends = default,mesecons,mesecons_mvps,screwdriver,pipeworks,qos
+optional_depends = default, mesecons, mesecons_mvps, screwdriver, pipeworks, qos, vizlib


### PR DESCRIPTION
Adds detection area visualizations to the camera and detector when `vizlib` is installed.

Closes https://github.com/pandorabox-io/in-game/issues/320