### PR TITLE
button: fix problems that occur when combined with other devices

### DIFF
--- a/switches.lua
+++ b/switches.lua
@@ -15,12 +15,14 @@ end
 digistuff.button_push = function(pos,node,player)
 	local meta = minetest.get_meta(pos)
 	if meta:get_int("protected") == 1 and not digistuff.check_protection(pos,player) then return end
-	digilines.receptor_send(pos, digistuff.button_get_rules(node), meta:get_string("channel"), meta:get_string("msg"))
 	local newnode = "digistuff:button_on_pushed"
 	if meta:get_int("mlight") == 1 and (node.name == "digistuff:button_off" or node.name == "digistuff:button_off_pushed") then newnode = "digistuff:button_off_pushed" end
-	if node.name ~= newnode then minetest.swap_node(pos, {name = newnode, param2=node.param2}) end
-	if digistuff.mesecons_installed then minetest.sound_play("mesecons_button_push", {pos=pos}) end
-	minetest.get_node_timer(pos):start(0.25)
+	if node.name ~= newnode then
+		minetest.swap_node(pos, {name = newnode, param2=node.param2})
+		if digistuff.mesecons_installed then minetest.sound_play("mesecons_button_push", {pos=pos}) end
+		minetest.get_node_timer(pos):start(0.25)
+		digilines.receptor_send(pos, digistuff.button_get_rules(node), meta:get_string("channel"), meta:get_string("msg"))
+	end
 end
 
 digistuff.button_handle_digilines = function(pos,node,channel,msg)


### PR DESCRIPTION
The button sends custom strings as digiline messages. This can be used to skip the luacontroller (and thus the 1-serverstep-delay from it) when activating certain devices.
These devices might start actions the button has to take into account:

The map might change:
place a button so that it will be moved by the digiline piston it activates with its message. 
-> the button duplicates, fix: swap the button before calling `digilines.receptor_send`

Infinite Feedback loop with a pipeworks deployer:
Have a deployer with a stick in its first inv slot so that it will right-click a button with the message "activate 1"
-> Stack Overflow, fix: do not call `digilines.receptor_send` if the button is already pressed.