### PR TITLE
Touchscreen fixes

### DIFF
--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -156,7 +156,7 @@ local function create_formspec(meta, data)
 	if meta:get_int("no_prepend") == 1 then
 		fs = fs.."no_prepend[]"
 	end
-	if not meta:get("real_coordinates") and not meta:get("realcoordinates") then
+	if meta:get_int("real_coordinates") == 0 then
 		fs = fs.."real_coordinates[false]"
 	end
 	local focus = meta:get("focus")

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -156,7 +156,10 @@ local function create_formspec(meta, data)
 	if meta:get_int("no_prepend") == 1 then
 		fs = fs.."no_prepend[]"
 	end
-	if meta:get_int("real_coordinates") == 0 then
+	if (
+		meta:contains("real_coordinates") and meta:get_int("real_coordinates")
+		or meta:get_int("realcoordinates") -- old screen
+	) == 0 then
 		fs = fs.."real_coordinates[false]"
 	end
 	local focus = meta:get("focus")

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -20,7 +20,7 @@ end
 local function modify_element_string(old, values)
 	local e = string.match(old, "^(.-)%[")
 	local element = formspec_elements[e]
-	if type(element) == "function" then
+	if type(element) ~= "table" then
 		return old  -- No-op for special elements, as there is no format string
 	end
 	local old_values = {string.match(old, element[5])}

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -156,10 +156,7 @@ local function create_formspec(meta, data)
 	if meta:get_int("no_prepend") == 1 then
 		fs = fs.."no_prepend[]"
 	end
-	if (
-		meta:contains("real_coordinates") and meta:get_int("real_coordinates")
-		or meta:get_int("realcoordinates") -- old screen
-	) == 0 then
+	if (meta:get("real_coordinates") or meta:get("realcoordinates")) ~= "1" then
 		fs = fs.."real_coordinates[false]"
 	end
 	local focus = meta:get("focus")

--- a/touchscreen.lua
+++ b/touchscreen.lua
@@ -18,7 +18,7 @@ local function create_element_string(element, values)
 end
 
 local function modify_element_string(old, values)
-	local e = string.match(old, "^(.-)%[")
+	local e = string.match(old, "^(.-)%[[^[]*%]$")
 	local element = formspec_elements[e]
 	if type(element) ~= "table" then
 		return old  -- No-op for special elements, as there is no format string


### PR DESCRIPTION
commit 1:
adding a table with color defined causes the string to start with `tableoptions` => `formspec_elements[e] = nil` => crash on L26
```lua
digiline_send("ts", {
    {
        command = "clear"
    },
    {
        command = "add",
        element = "table",
        color = "red"
    },
    {
        command = "modify",
        index = 1,
    }
})
```

commit 2:
setting real_coordinates once caused them to always be true in the formspec, no matter of the actual value.
```lua
mem = mem or {}
mem.real_coordinates = not mem.real_coordinates
digiline_send("ts", {
    {
        command = "clear" 
    },
    {
        command = "set", 
        real_coordinates = mem.real_coordinates
    },
    {
        command = "add",
        element = "button",
        name = "start",
        label = mem.real_coordinates and "real_coordinates=true" or "real_coordinates=false",  
        X = 0.3,  
        Y = 0.3, 
        W = 4,
        H = 4 
    },
})
```

commit 3:
trying to modify an item_grid caused the whole grid to disappear, except for the last item.
```lua
digiline_send("ts", {
    {
        command = "clear"
    },
    {
        command = "add",
        element = "item_grid",
        X = 0,
        Y = 0,
        W = 2,
        H = 2,
        name = "grid",
        spacing = 0,
        size = 1,
        interactable = true,
        items = {
            "default:dirt 99",
            "default:stone 42",
            "default:apple 13",
            "default:torch"
        },
        offset = 1,
    },
    {
        command = "modify",
        index= 1,
        X = 1
    },
})
```