### PR TITLE
Add (0,-1,0) rule to camera

### DIFF
--- a/camera.lua
+++ b/camera.lua
@@ -1,3 +1,7 @@
+local rules = table.copy(digilines.rules.default)
+-- 0,-1,0 rule is to allow the camera to conduct down its pole
+-- and into digimese/streets mod poles/etc., such as for traffic signals
+table.insert(rules, vector.new(0,-1,0))
 
 local formspec = "size[8,4]"..
 	"field[1.3,1;6,1;channel;Channel;${channel}]"..
@@ -41,7 +45,7 @@ local function search_for_players(pos, send_empty)
 	end
 	if #found > 0 or send_empty == true then
 		local channel = meta:get_string("channel")
-		digilines.receptor_send(pos, digilines.rules.default, channel, found)
+		digilines.receptor_send(pos, rules, channel, found)
 	end
 	return true
 end
@@ -121,7 +125,9 @@ minetest.register_node("digistuff:camera", {
 	on_timer = search_for_players,
 	on_punch = minetest.get_modpath("vizlib") and show_area or nil,
 	digiline = {
-		receptor = {},
+		receptor = {
+			rules = rules,
+		},
 		effector = {
 			action = function(pos, node, channel, msg)
 				local meta = minetest.get_meta(pos)

--- a/spec/fixtures/digilines.lua
+++ b/spec/fixtures/digilines.lua
@@ -1,1 +1,19 @@
-digilines = {}
+mineunit:set_modpath("digilines", "spec/fixtures")
+digilines = {
+	rules = {
+		default = {
+			{x= 0, y= 0, z=-1},
+			{x= 1, y= 0, z= 0},
+			{x=-1, y= 0, z= 0},
+			{x= 0, y= 0, z= 1},
+			{x= 1, y= 1, z= 0},
+			{x= 1, y=-1, z= 0},
+			{x=-1, y=1,  z= 0},
+			{x=-1, y=-1, z= 0},
+			{x= 0, y=1,  z= 1},
+			{x= 0, y=-1, z= 1},
+			{x= 0, y=1,  z=-1},
+			{x= 0, y=-1, z=-1},
+		}
+	}
+}


### PR DESCRIPTION
This is an alternate to #80 (see discussion there) and fixes #63.

This modifies the conduction rules when the camera outputs a signal slightly. The existing rules are kept (no offset is introduced like in #80) but an extra rule is added that conducts straight downwards.

This allows the original intended use of the cameras (vehicle detection for traffic signals) to work again:
<img width="1920" height="1116" alt="screenshot_20250711_221233" src="https://github.com/user-attachments/assets/819f2ca3-e1e3-4a84-badf-bea8763c4902" />
