### PR TITLE
Add fake shaders, affine/linear transformations and convolution matrix to GPU shaders

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,5 +1,5 @@
 unused_args = false
-max_line_length = 300  -- TODO: fix line lengths
+max_line_length = 300 -- TODO: fix line lengths
 --std = "luanti+max"
 
 globals = {
@@ -11,7 +11,8 @@ read_globals = {
 	-- Builtin
 	"core",
 	"minetest",
-	table = {fields = {"copy"}},
+	table = { fields = { "copy" } },
+	math = { fields = { "round" } },
 	"vector",
 	"ItemStack",
 	"DIR_DELIM",
@@ -27,4 +28,3 @@ read_globals = {
 exclude_files = {
 	"**/spec/**",
 }
-

--- a/docs/gpu.txt
+++ b/docs/gpu.txt
@@ -244,9 +244,52 @@ Command: convolutionmatrix
 -------------------------
 See https://en.wikipedia.org/wiki/Kernel_(image_processing)
 
-Allows you to blur/sharpen/edge detection or do other fun stuff on an image using some numbers in a table.
+Allows you to blur/sharpen/edge detection or do other fun stuff on an image using some numbers in a table. Feel free to experiment.
 
 Parameters:
 buffer [integer 0-7]: The buffer to perform the operation on
-matrix [nested 3x3 or 5x5 table, anything else is not accepted]: The convolution matrix/image kernel
+matrix [nested 3x3 or 5x5 table]: The convolution matrix/image kernel
 
+Example:
+{
+   command = "convolutionmatrix",
+   buffer = 0,
+   matrix = {
+      { 0, 1  , 0},
+      { 1,-3.8, 1},
+      { 0, 1  , 0}
+   }
+}
+
+Command: transform
+------------------
+Allows you to rotate/shear/scale/move an area of the buffer.
+
+See:
+https://en.wikipedia.org/wiki/Affine_transformation#Image_transformation
+https://en.wikipedia.org/wiki/Rotation_matrix
+
+Parameters:
+buffer [integer 0-7]: The buffer to perform the operation on.
+x1 [integer 0-64]: x1, y1, x2, y2 will be the region that the transform will operate on.
+y1 [integer 0-64]
+x2 [integer 0-64]
+y2 [integer 0-64]
+matrix [2x2 nested table or 3x3 nested table]: The transformation/affine matrix
+center_x [number] - The X coordinate for the center of the transformation (for e.g. the center of rotation)
+center_y [number] - The Y coordinate for the center of the transformation (for e.g. the center of rotation)
+interpolation [boolean, default: true]: If true or unspecified, uses bilinear interpolation, if false it uses nearest neighbor
+
+Example:
+{
+   command = "transform",
+   buffer = 0,
+   x1 = 0, y1 = 0, x2 = 64, y2 = 64,
+   center_x = 32, center_y = 32,
+   matrix = {
+      {1,0    ,0},   -- changes to X coordinate
+      {0,1    ,0},   -- changes to Y coordinate
+      {-0.01,0.01,1} -- perspective stuff, feel free to experiment with this
+   },
+   interpolation = false
+}

--- a/docs/gpu.txt
+++ b/docs/gpu.txt
@@ -170,3 +170,73 @@ y [integer 1-64]: The Y position of the top of the image.
 xsize [integer 1-64]: The width of the image. Must be the same as the original image or the image will be severely distorted.
 ysize [integer 1-64]: The height of the image. Should be the same as the original image.
 data [string]: The packed image to load.
+
+Command: fakeshader
+-------------------
+
+Allows you to run code that executes for every pixel in a buffer. It isn't a "real" shader because it isn't ran on the GPU and it is ran only on a CPU single thread.
+
+Parameters:
+buffer [integer 0-7]: The buffer to run the shader on
+code [string, lua code]: The code of the shader
+
+The code that you write gets called for each pixel, and has to return the r, g, b values (integers between 0 and 255)
+
+In order to prevent abuse and lag, the shader code has some limitations:
+- The shader can only run for 150*64*64 instructions (this is more than the mesecons luacontroller, but you are not allowed to use the laggy string operation instructions, and in practice it's less)
+- Declaring strings is not allowed
+   - More specifically, you cannot have in your code: " ' [[ [<any amount of equal signs>[
+   - **You also cannot have those characters in comments, and you cannot declare multi line comments**
+   - If possible, try minimizing the amount of comments, so you don't accidentally run into this restriction
+   - This was done because it would be difficult to limit string concatination and declaring long strings if they were allowed.
+- The maximum length of your code is 1000 characters
+
+The environment of shaders (things avaliable in shader code):
+- math: All standard math functions as documented in the lua manual, except math.randomseed
+- xsize: The width of the buffer
+- ysize: the height of the buffer
+- x: The current x coordinate of the pixel that is being processed
+- y: The current y coordinate of the pixel that is being processed
+- color: the current color of the pixel being processed
+- r, g, b = get_color(x, y): Allows you to get a color from the buffer
+
+
+Shader code examples (inside "```"):
+
+Gradient:
+```
+return (x/xsize)*255, (y/ysize)*255, 0
+```
+
+Grid:
+```
+return 255*math.sin(x/2), 255*math.sin(y/2), 0
+```
+
+Noise:
+```
+return math.random()*255, math.random()*255, math.random()*255
+```
+
+Classic showcase of how RGB works:
+```
+local r = 16 -- radius
+local dist = 10 -- distance between circles
+local cX, cY = x-(xsize/2), y-(ysize/2) -- center X, center Y
+local r2 = r^2
+
+local red_circle   = r2 - (cX^2+(cY+dist)^2) -- thanks pythagoras
+local green_circle = r2 - ((cX+dist)^2+cY^2)
+local blue_circle  = r2 - ((cX-dist)^2+cY^2)
+
+-- make them solid
+red_circle, green_circle, blue_circle =
+ math.min(1, red_circle)*255,
+ math.min(1, green_circle)*255,
+ math.min(1, blue_circle)*255
+
+return red_circle, green_circle, blue_circle
+```
+
+I am pretty sure you could also run the Conway's Game of Life with this, but that is an excercise for the viewer.
+

--- a/docs/gpu.txt
+++ b/docs/gpu.txt
@@ -197,8 +197,8 @@ The environment of shaders (the only things avaliable in shader code):
 - ysize: the height of the buffer
 - x: The current x coordinate of the pixel that is being processed
 - y: The current y coordinate of the pixel that is being processed
-- color: the current color of the pixel being processed
-- r, g, b = get_color(x, y): Allows you to get a color from the buffer
+- color = {r=[0-255], g=[0-255], b=[0-255]}: the current color of the pixel being processed
+- get_color(x, y): Allows you to get a color from the buffer, returns 3 values: r, g, b
 
 If the shader code is invalid or throws an error, the digilines GPU will send the error message to digilines, under the channel that it has been configured with.
 

--- a/docs/gpu.txt
+++ b/docs/gpu.txt
@@ -197,7 +197,9 @@ The environment of shaders (the only things avaliable in shader code):
 - ysize: the height of the buffer
 - x: The current x coordinate of the pixel that is being processed
 - y: The current y coordinate of the pixel that is being processed
-- color = {r=[0-255], g=[0-255], b=[0-255]}: the current color of the pixel being processed
+- r: The red value of the current pixel being processed
+- g: The green value of the current pixel being processed
+- b: The blue value of the current pixel being processed
 - get_color(x, y): Allows you to get a color from the buffer, returns 3 values: r, g, b
 
 If the shader code is invalid or throws an error, the digilines GPU will send the error message to digilines, under the channel that it has been configured with.
@@ -222,10 +224,10 @@ return math.random()*255, math.random()*255, math.random()*255
 
 Classic showcase of how RGB works:
 ```
-local r = 16 -- radius
+local radius = 16 -- radius, not named "r" because that would shadow the "r" global
 local dist = 10 -- distance between circles
 local cX, cY = x-(xsize/2), y-(ysize/2) -- center X, center Y
-local r2 = r^2
+local r2 = radius^2
 
 local red_circle   = r2 - (cX^2+(cY+dist)^2) -- thanks pythagoras
 local green_circle = r2 - ((cX+dist)^2+cY^2)

--- a/docs/gpu.txt
+++ b/docs/gpu.txt
@@ -273,10 +273,10 @@ https://en.wikipedia.org/wiki/Rotation_matrix
 
 Parameters:
 buffer [integer 0-7]: The buffer to perform the operation on.
-x1 [integer 0-64]: x1, y1, x2, y2 will be the region that the transform will operate on.
-y1 [integer 0-64]
-x2 [integer 0-64]
-y2 [integer 0-64]
+x1 [integer 1-64]: x1, y1, x2, y2 will be the region that the transform will operate on.
+y1 [integer 1-64]
+x2 [integer 1-64]
+y2 [integer 1-64]
 matrix [2x2 nested table or 3x3 nested table]: The transformation/affine matrix, feel free to experiment
 center_x [number] - The X coordinate for the center of the transformation (for example the center of a rotation), can be any number, doesn't even need to be on the buffer
 center_y [number] - The Y coordinate for the center of the transformation (for example the center of a rotation), can be any number, doesn't even need to be on the buffer

--- a/docs/gpu.txt
+++ b/docs/gpu.txt
@@ -191,7 +191,7 @@ In order to prevent abuse and lag, the shader code has some limitations:
    - This was done because it would be difficult to limit string concatination and declaring long strings if they were allowed.
 - The maximum length of your code is 1000 characters
 
-The environment of shaders (things avaliable in shader code):
+The environment of shaders (the only things avaliable in shader code):
 - math: All standard math functions as documented in the lua manual, except math.randomseed
 - xsize: The width of the buffer
 - ysize: the height of the buffer
@@ -199,6 +199,8 @@ The environment of shaders (things avaliable in shader code):
 - y: The current y coordinate of the pixel that is being processed
 - color: the current color of the pixel being processed
 - r, g, b = get_color(x, y): Allows you to get a color from the buffer
+
+If the shader code is invalid or throws an error, the digilines GPU will send the error message to digilines, under the channel that it has been configured with.
 
 
 Shader code examples (inside "```"):
@@ -254,16 +256,16 @@ Example:
 {
    command = "convolutionmatrix",
    buffer = 0,
-   matrix = {
-      { 0, 1  , 0},
-      { 1,-3.8, 1},
-      { 0, 1  , 0}
+   matrix = { -- edge detection
+      { 0, 1 , 0},
+      { 1, -4, 1},
+      { 0, 1 , 0}
    }
 }
 
 Command: transform
 ------------------
-Allows you to rotate/shear/scale/move an area of the buffer.
+Allows you to rotate/shear/scale/move an area of a buffer.
 
 See:
 https://en.wikipedia.org/wiki/Affine_transformation#Image_transformation
@@ -275,21 +277,35 @@ x1 [integer 0-64]: x1, y1, x2, y2 will be the region that the transform will ope
 y1 [integer 0-64]
 x2 [integer 0-64]
 y2 [integer 0-64]
-matrix [2x2 nested table or 3x3 nested table]: The transformation/affine matrix
-center_x [number] - The X coordinate for the center of the transformation (for e.g. the center of rotation)
-center_y [number] - The Y coordinate for the center of the transformation (for e.g. the center of rotation)
+matrix [2x2 nested table or 3x3 nested table]: The transformation/affine matrix, feel free to experiment
+center_x [number] - The X coordinate for the center of the transformation (for example the center of a rotation), can be any number, doesn't even need to be on the buffer
+center_y [number] - The Y coordinate for the center of the transformation (for example the center of a rotation), can be any number, doesn't even need to be on the buffer
 interpolation [boolean, default: true]: If true or unspecified, uses bilinear interpolation, if false it uses nearest neighbor
 
-Example:
+Examples:
 {
    command = "transform",
    buffer = 0,
    x1 = 0, y1 = 0, x2 = 64, y2 = 64,
    center_x = 32, center_y = 32,
    matrix = {
-      {1,0    ,0},   -- changes to X coordinate
-      {0,1    ,0},   -- changes to Y coordinate
-      {-0.01,0.01,1} -- perspective stuff, feel free to experiment with this
+      {1,0.5,0},   -- changes to X coordinate ( when it is {1,0,0} nothing changes, in this case it will shear a bit)
+      {0,1,0},     -- changes to Y coordinate ( when it is {0,1,0} nothing changes)
+      {0,0,1}      -- changes to perspective (if you change this then it isn't an affine transform) (when it is {0,0,1} nothing changes)
    },
    interpolation = false
+}
+
+
+local angle = math.pi/4 -- 45 degrees
+{
+   command = "transform",
+   buffer = 0,
+   x1 = 0, y1 = 0, x2 = 64, y2 = 64,
+   center_x = 32, center_y = 32,
+   matrix = { -- rotates by the angle
+      {math.cos(angle), -math.sin(angle)},
+      {math.sin(angle), math.cos(angle},
+   },
+   interpolation = false,
 }

--- a/docs/gpu.txt
+++ b/docs/gpu.txt
@@ -183,7 +183,7 @@ code [string, lua code]: The code of the shader
 The code that you write gets called for each pixel, and has to return the r, g, b values (integers between 0 and 255)
 
 In order to prevent abuse and lag, the shader code has some limitations:
-- The shader can only run for 150*64*64 instructions (this is more than the mesecons luacontroller, but you are not allowed to use the laggy string operation instructions, and in practice it's less)
+- The shader can only run for 200*64*64 instructions (this is more than the mesecons luacontroller, but you are not allowed to use the laggy string operation instructions, and in practice it's less)
 - Declaring strings is not allowed
    - More specifically, you cannot have in your code: " ' [[ [<any amount of equal signs>[
    - **You also cannot have those characters in comments, and you cannot declare multi line comments**
@@ -239,4 +239,14 @@ return red_circle, green_circle, blue_circle
 ```
 
 I am pretty sure you could also run the Conway's Game of Life with this, but that is an excercise for the viewer.
+
+Command: convolutionmatrix
+-------------------------
+See https://en.wikipedia.org/wiki/Kernel_(image_processing)
+
+Allows you to blur/sharpen/edge detection or do other fun stuff on an image using some numbers in a table.
+
+Parameters:
+buffer [integer 0-7]: The buffer to perform the operation on
+matrix [nested 3x3 or 5x5 table, anything else is not accepted]: The convolution matrix/image kernel
 

--- a/gpu.lua
+++ b/gpu.lua
@@ -326,13 +326,14 @@ local function run_shader(env, buffer, new_buffer, f)
 			color.r, color.g, color.b = unpack_color(buffer[y][x])
 			local r, g, b = f()
 			if type(r) ~= "number" or type(g) ~= "number" or type(b) ~= "number" then
-				return false,
+				error(
 					"You are supposed to return r,g,b where all of them are numbers, you sent: "
 						.. tostring(r)
 						.. ", "
 						.. tostring(g)
 						.. ", "
 						.. tostring(b)
+				)
 			end
 			r, g, b = -- rgb must be an integer between 0 and 255
 				math.min(255, math.max(0, math.floor(r))),
@@ -825,9 +826,11 @@ local function runcommand(pos, meta, command)
 		end
 
 		ok, errmsg = pcall(run_shader, env, buffer, new_buffer, f) -- nested pcall because that is how mesecons does it and i already had a nightmare bug where the debug hook somehow escaped containment and started error'ing in random functions
-		if not ok then return ok, errmsg end
-
-		write_buffer(meta, bufnum, new_buffer)
+		if not ok then
+			return ok, errmsg
+		else
+			write_buffer(meta, bufnum, new_buffer)
+		end
 	elseif command.command == "convolutionmatrix" then
 		local convolution_matrix = command.matrix
 		if not validate_matrix(convolution_matrix, { [3] = true, [5] = true }) then return end

--- a/gpu.lua
+++ b/gpu.lua
@@ -318,7 +318,6 @@ local function write_buffer(meta, bufnum, buffer)
 end
 
 local function run_shader(env, buffer, new_buffer, f)
-	local color = env.color
 	for y = 1, buffer.ysize do
 		for x = 1, buffer.xsize do
 			env.x = x

--- a/gpu.lua
+++ b/gpu.lua
@@ -323,7 +323,7 @@ local function run_shader(env, buffer, new_buffer, f)
 		for x = 1, buffer.xsize do
 			env.x = x
 			env.y = y
-			color.r, color.g, color.b = unpack_color(buffer[y][x])
+			env.r, env.g, env.b = unpack_color(buffer[y][x])
 			local r, g, b = f()
 			if type(r) ~= "number" or type(g) ~= "number" or type(b) ~= "number" then
 				error(
@@ -814,7 +814,10 @@ local function runcommand(pos, meta, command)
 			ysize = buffer.ysize,
 
 			-- Variables that change for each pixel:
-			color = {},
+			r = 0,
+			g = 0,
+			b = 0,
+
 			x = 0,
 			y = 0,
 		}

--- a/gpu.lua
+++ b/gpu.lua
@@ -762,8 +762,10 @@ local function runcommand(pos, meta, command)
 			return false, "Cannot create strings in shader code"
 		end
 
+		local ok, f, errmsg
+
 		-- set up the sandbox
-		local f, errmsg = loadstring(command.code)
+		f, errmsg = loadstring(command.code)
 		if not f or errmsg then return false, errmsg end
 
 		if core.global_exists("jit") then jit.off(f, true) end -- debug count hooks don't work with JIT, so turn it off for that function
@@ -822,7 +824,7 @@ local function runcommand(pos, meta, command)
 			new_buffer[y] = {}
 		end
 
-		local ok, errmsg = pcall(run_shader, env, buffer, new_buffer, f) -- nested pcall because that is how mesecons does it and i already had a nightmare bug where the debug hook somehow escaped containment and started error'ing in random functions
+		ok, errmsg = pcall(run_shader, env, buffer, new_buffer, f) -- nested pcall because that is how mesecons does it and i already had a nightmare bug where the debug hook somehow escaped containment and started error'ing in random functions
 		if not ok then return ok, errmsg end
 
 		write_buffer(meta, bufnum, new_buffer)
@@ -834,8 +836,7 @@ local function runcommand(pos, meta, command)
 		local half_matrix_size = math.floor(matrix_size / 2)
 
 		local new_buffer = { xsize = buffer.xsize, ysize = buffer.ysize }
-
-		local xsize, ysize = buffer.xsize, buffer.ysize
+		xsize, ysize = buffer.xsize, buffer.ysize
 
 		local number_buffer = {} -- a cache to avoid computing unpack_color, yes it would be wiser to just not use strings but blame the first developer that worked on the digistuff GPU, also yes this SIGNIFICANTLY speeds up calculations at least on luajit
 		for y = 1, ysize do
@@ -868,7 +869,7 @@ local function runcommand(pos, meta, command)
 		local matrix = command.matrix -- 2x2 if linear, 3x3 if affine
 		if not validate_matrix(matrix, { [2] = true, [3] = true }) then return end
 
-		local x1, y1, x2, y2 = validate_area(buffer, command.x1, command.y1, command.x2, command.y2, false)
+		x1, y1, x2, y2 = validate_area(buffer, command.x1, command.y1, command.x2, command.y2, false)
 		if not x1 then return end
 		local transparent = validate_color(command.transparent, "#000000")
 		local interpolation = command.interpolation
@@ -900,7 +901,7 @@ local function runcommand(pos, meta, command)
 				local new_x, new_y = transform(x - center_x, y - center_y, matrix)
 				new_x, new_y = new_x + center_x, new_y + center_y
 				if new_x == new_x and new_y == new_y then -- checking against NaN
-					local color = interpolate(buffer, cache, new_x, new_y)
+					color = interpolate(buffer, cache, new_x, new_y)
 					if color and color ~= transparent then changed_buffer[y][x] = color end
 				end
 			end

--- a/gpu.lua
+++ b/gpu.lua
@@ -758,7 +758,9 @@ local function runcommand(pos, meta, command)
 		if type(command.code) ~= "string" then return false, "No code provided" end
 		if #command.code > MAX_SHADER_CODE_LENGTH then return false, "Code too large" end
 
-		if command.code:byte(1) == 27 then return false, "No bytecode!" end -- This is technically not needed, but if someone turned off mod security (don't do that!!!!) then someone could abuse bytecode
+		-- This is technically not needed, but if someone turned off mod security (don't do that!) then someone could abuse bytecode
+		-- (mod security disallows bytecode)
+		if command.code:byte(1) == 27 then return false, "No bytecode" end
 
 		if command.code:find('"', 1, true) or command.code:find("%[=*%[") then
 			return false, "Cannot create strings in shader code"

--- a/gpu.lua
+++ b/gpu.lua
@@ -758,6 +758,8 @@ local function runcommand(pos, meta, command)
 		if type(command.code) ~= "string" then return false, "No code provided" end
 		if #command.code > MAX_SHADER_CODE_LENGTH then return false, "Code too large" end
 
+		if command.code:byte(1) == 27 then return false, "No bytecode!" end -- This is technically not needed, but if someone turned off mod security (don't do that!!!!) then someone could abuse bytecode
+
 		if command.code:find('"', 1, true) or command.code:find("%[=*%[") then
 			return false, "Cannot create strings in shader code"
 		end

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,6 @@
+# https://github.com/JohnnyMorganz/StyLua - its a code formatter
+syntax = "LuaJIT"
+column_width = 120
+line_endings = "Unix"
+indent_type = "Tabs"
+collapse_simple_statement = "ConditionalOnly"


### PR DESCRIPTION
All of the features are documented in docs/gpu.txt

## Fake shaders
- Performance: Shaders take about 5~20ms for me (when i run the RGB showcase)
- Security
  - Shaders are limited in almost the same way as mesecons luacontroller sandboxes (debug hooks to control the amount of time that shaders can take up, setfenv to control their environment, strings aren't sandboxed because the shader sandbox can't use strings)
  - They should be more secure than mesecons luacontrollers as they don't allow access to strings, so they don't have the weakness of string concatination causing lag

## Convolution matrix
- Performance: Takes about 10-25ms for a 64x64 image, with a 5x5 matrix for me
  - It could potentially be even faster if digistuff GPUs just stored colors in plain numbers, should I contribute that? If I did I would also make them store the buffer in just a plain array (like ``buffer[y * xsize + x] = color`` I probably messed that up but you get the idea), but everything could potentially be faster if that was the case

## Affine/linear transformations
- Performance: 5~10ms if not interpolated, 10-20ms when interpolated but tends to stabilize at 5~10ms?
   - Also when testing this I discovered that most things are MUCH faster (like 0~2ms) when my luanti window is unfocused, weird, I am not sure if this is a byproduct of me measuring things with os.clock, or if it's geniuenly just faster and that I shouldn't care 

### Notes
- All the performance testing was done with lightly modified versions of the showcase code, and with my laptop's power profile being power saving, so even a cheap server will probably be faster than that
- The invert_3x3_matrix and invert_2x2 matrix functions were done by chatGPT (I was having gaps in the buffer when scaling so I asked chatgpt about them and it suggested inverting the matrix and doing it a slightly different way)

### Showcase:
<img width="656" height="441" alt="image" src="https://github.com/user-attachments/assets/dfb7c8d3-309f-4772-b29c-209e006eef02" />
<details>
<summary>Showcase code:</summary>

```lua
--interrupt(.5)
local shader_cmd = {command="fakeshader", buffer = 1,
code = [[
local r = 16 -- radius
local dist = 10 -- distance between circles
local cX, cY = x-(xsize/2), y-(ysize/2) -- center X, center Y
local r2 = r^2

local red_circle   = r2 - (cX^2+(cY+dist)^2) -- thanks pythagoras
local green_circle = r2 - ((cX+dist)^2+cY^2)
local blue_circle  = r2 - ((cX-dist)^2+cY^2)

-- make them solid
red_circle, green_circle, blue_circle =
 math.min(1, red_circle)*255,
 math.min(1, green_circle)*255,
 math.min(1, blue_circle)*255

return red_circle, green_circle, blue_circle
]]}


local a,b,c = -1, .3/8, 4
local convolution_matrix = {
{0,0,a,0,0},
{0,b,b,b,0},
{a,b,c,b,a},
{0,b,b,b,0},
{0,0,a,0,0},
}

local angle = math.pi/4

local transform_by = {
{math.cos(angle), -math.sin(angle),0},
{math.sin(angle), math.cos(angle),0},
{-.01,0,0.8}
}

digiline_send("gpu",{
   {command ="createbuffer",buffer=1, xsize = 64, ysize = 64, fill = "#000000"},
   shader_cmd,
{
command = "convolutionmatrix",
buffer = 1,
matrix = convolution_matrix,
},
{
command = "transform",
buffer = -1,
matrix = transform_by,
x1=1,
y1=1,
x2=64,
y2=64,
center_x = 32,
center_y = 32,
interpolation=false
},

   {command = "sendregion", buffer=1, channel = "1", x1=1,y1=1,x2=64,y2=64},

})
```
</details>

<br>
Also, would it be ok to remove permanent saving of digistuff GPU buffers to node meta and replace that with just a temporary table outside of the GPU? I am not sure if using minetest.serialize on GPU buffers is a good idea because it has to build up the `return { { "ffffff", "aaaaa", ...}, ... }` which I *assume* isn't performant...

